### PR TITLE
Fix for issue #3 "CPU info for i386/x86_64 processors is frequently wrong"

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
@@ -85,7 +85,7 @@ sub run {
 			}
 
 			$current->{TYPE} = $1 if /^model\sname\s*:\s*(.+)/i;
-			$current->{CORES} = $1 if /^cpu\scores\s*:\s*(\d+)/i;
+			$current->{CORES} = $1 if /^siblings\s*:\s*(\d+)/i;
 			$current->{CURRENT_SPEED} = $1 if /^cpu\sMHz\s*:\s*(\d+)/i;
 			$index = $1 if /^physical\sid\s*:\s*(\d+)/i;
 

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
@@ -3,7 +3,6 @@ package Ocsinventory::Agent::Backend::OS::Linux::Archs::i386::CPU;
 use strict;
 
 use Config;
-use Data::Dumper;
 
 sub check { can_read("/proc/cpuinfo"); can_run("arch"); }
 

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
@@ -8,101 +8,101 @@ sub check { can_read("/proc/cpuinfo"); can_run("arch"); }
 
 sub run {
 
-    my $params = shift;
-    my $common = $params->{common};
+	my $params = shift;
+	my $common = $params->{common};
 
-    my @cpu;
-    my $current;
-    my $cpuarch = `arch`;
-    chomp($cpuarch);
-    my $cpusocket;
-    my $siblings;
-    my $cpucores;
-    my $cpuspeed;
-    my $coreid;
+	my @cpu;
+	my @cache;
+	my $current;
+	my $cpuarch = `arch`;
+	chomp($cpuarch);
+	my $datawidth;
+	my $index;
+	my $cpucount = 0;
+	my $l2cacheid;
+	my $l2cachesection;
 
-	$cpucores=0;
-	$siblings=0;
-    open CPUINFO, "</proc/cpuinfo" or warn;
-    foreach(<CPUINFO>) {
+	if ($cpuarch eq "x86_64"){
+		$datawidth = 64;
+	} else {
+		$datawidth = 32;
+	}
 
-        if (/^vendor_id\s*:\s*(Authentic|Genuine|)(.+)/i) {
-			$cpucores++;
-            $current->{MANUFACTURER} = $2;
-            $current->{MANUFACTURER} =~ s/(TMx86|TransmetaCPU)/Transmeta/;
-            $current->{MANUFACTURER} =~ s/CyrixInstead/Cyrix/;
-            $current->{MANUFACTURER} =~ s/CentaurHauls/VIA/;
-        }
-
-        if (/^siblings\s*:\s*(\d+)/i){
-			$siblings++;
-		}
-		$current->{CURRENT_SPEED} = $1 if /^cpu\sMHz\s*:\s*(\d+)/i;
-        $current->{TYPE} = $1 if /^model\sname\s*:\s*(.+)/i;
-	    $current->{L2CACHESIZE} = $1 if /^cache\ssize\s*:\s*(\d+)/i;
-    }
-
-	# /proc/cpuinfo provides real time speed processor.
-	# Get optimal speed with dmidecode command
-  	# Get also cpu cores with dmidecode command
-  	# Get also voltage information with dmidecode command
+	# Prefer dmidecode to give us the information we're looking for
    	@cpu = `dmidecode -t processor`;
-	$cpuspeed=0;
-	$cpusocket=0;
    	for (@cpu){
-		if (/Processor\sInformation/i){
-			$cpusocket++;
-			if ($cpuspeed != 0){
-				if ($cpusocket > $cpucores) {
-					last;
+		$current->{CORES} = $1 if /Core\sCount:\s*(\d+)/i;
+		$current->{CURRENT_SPEED} = $1 if /Current\sSpeed:\s*(\d+)/i;
+		$current->{HPT} = 'yes' if /^\s*HTT\s/i;
+		$current->{MANUFACTURER} = $1 if /Manufacturer:\s*(.*)/i;
+		$current->{SOCKET} = $1 if /Upgrade:\s*Socket\s(.*)/i;
+		$current->{SPEED} = $1 if /Max\sSpeed:\s*(\d+)/i;
+		$current->{TYPE} = $1 if /Version:\s*(.*)/i;
+		$current->{VOLTAGE} = $1 if /Voltage:\s*(.*)V/i;
+		$l2cacheid = $1 if /L2\sCache\sHandle:\s*(0x[0-9a-f]+)/i;
+
+		# Add and reset CPU when encountering a blank line
+		if (/^\s*$/ && defined $current){
+			$current->{CPUARCH} = $cpuarch;
+			$current->{DATA_WIDTH} = $datawidth;
+
+			# replace repeated whitespace, because some processors like to do that
+			$current->{TYPE} =~ s/\s{2,}/ /g;
+
+			if (defined $l2cacheid){
+				@cache = `dmidecode -t cache`;
+				$l2cachesection = 0;
+				for my $l2cacheline (@cache){
+					if ($l2cacheline =~ /Handle (0x[0-9a-f]+)/i){
+						$l2cachesection = $1 eq $l2cacheid;
+					}
+
+					if ($l2cachesection && $l2cacheline =~ /Installed\sSize:\s*([0-9]+)/i){
+						$current->{L2CACHESIZE} = $1;
+					}
 				}
 			}
-			$cpuspeed=0;
-		}	
 
-    	if (/Current\sSpeed:\s*(.*) (|MHz|GHz)/i){
-			$cpuspeed = $1;
-            $current->{SPEED} = $cpuspeed;
-		}
-
-        if (/Core\sCount:\s*(\d+)/i){
-            $current->{CORES} = $1;
-        } else {
-			$current->{CORES} = $cpucores;
-		}
-    	
-    	# Is(Are) CPU(s) hyperthreaded?
-    	if ($siblings == $current->{CORES}) {
-       		# Hyperthreading is off
-       		$current->{HPT}='on';
-    	} else {
-       		# Hyperthreading is on
-       		$current->{HPT}='off';
-    	}
-
-        if (/Voltage:\s*(.*)V/i){
-            $current->{VOLTAGE} = $1;
-        }
-
-        if (/Upgrade:\s*(.*)/i){
-            $current->{SOCKET} = $1;
-        }
-
-    	$current->{CPUARCH}=$cpuarch;
-		if ($cpuarch eq "x86_64"){
-			$current->{DATA_WIDTH}=64;
-    	} else {
-			$current->{DATA_WIDTH}=32;
-    	}
-		
-		$current->{NBSOCKET} = $cpusocket;
-
-		# Add CPU when Populated
-		if (/Status:\s*(.*),\s(.*)/i){
-            $current->{CPUSTATUS} = $2;
 			$common->addCPU($current);
-        }
-    }
+			$cpucount++;
+
+			undef $current;
+			undef $l2cacheid;
+		}
+	}
+
+  	# If dmidecode fails, fall back on /proc/cpuinfo
+	if ($cpucount eq 0) {
+		undef @cpu;
+
+		open CPUINFO, "</proc/cpuinfo" or warn;
+		for (<CPUINFO>) {
+			if (/^vendor_id\s*:\s*(Authentic|Genuine|)(.+)/i) {
+				$current->{MANUFACTURER} = $2;
+				$current->{MANUFACTURER} =~ s/(TMx86|TransmetaCPU)/Transmeta/;
+				$current->{MANUFACTURER} =~ s/CyrixInstead/Cyrix/;
+				$current->{MANUFACTURER} =~ s/CentaurHauls/VIA/;
+			}
+
+			$current->{TYPE} = $1 if /^model\sname\s*:\s*(.+)/i;
+			$current->{CORES} = $1 if /^cpu\scores\s*:\s*(\d+)/i;
+			$current->{CURRENT_SPEED} = $1 if /^cpu\sMHz\s*:\s*(\d+)/i;
+			$index = $1 if /^physical\sid\s*:\s*(\d+)/i;
+
+			if (/^\s*$/ && defined $index) {
+				$current->{HPT} = 'no' if $current->{HPT} ne 'yes';
+				$current->{CPUARCH} = $cpuarch;
+				$current->{DATA_WIDTH} = $datawidth;
+				$current->{TYPE} =~ s/\s{2,}/ /g;
+				$cpu[$index] = $current;
+				undef $current;
+			}
+		}
+
+		for my $current (@cpu) {
+			$common->addCPU($current);
+		}
+	}
 }
 
 1

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
@@ -43,28 +43,34 @@ sub run {
 
 		# Add and reset CPU when encountering a blank line
 		if (/^\s*$/ && defined $current){
-			$current->{CPUARCH} = $cpuarch;
-			$current->{DATA_WIDTH} = $datawidth;
+			if (defined $current->{CORES} &&
+				defined $current->{SPEED} &&
+				defined $current->{MANUFACTURER} &&
+				defined $current->{TYPE}
+			) {
+				$current->{CPUARCH} = $cpuarch;
+				$current->{DATA_WIDTH} = $datawidth;
 
-			# replace repeated whitespace, because some processors like to do that
-			$current->{TYPE} =~ s/\s{2,}/ /g;
+				# replace repeated whitespace, because some processors like to do that
+				$current->{TYPE} =~ s/\s{2,}/ /g;
 
-			if (defined $l2cacheid){
-				@cache = `dmidecode -t cache`;
-				$l2cachesection = 0;
-				for my $l2cacheline (@cache){
-					if ($l2cacheline =~ /Handle (0x[0-9a-f]+)/i){
-						$l2cachesection = $1 eq $l2cacheid;
-					}
+				if (defined $l2cacheid){
+					@cache = `dmidecode -t cache`;
+					$l2cachesection = 0;
+					for my $l2cacheline (@cache){
+						if ($l2cacheline =~ /Handle (0x[0-9a-f]+)/i){
+							$l2cachesection = $1 eq $l2cacheid;
+						}
 
-					if ($l2cachesection && $l2cacheline =~ /Installed\sSize:\s*([0-9]+)/i){
-						$current->{L2CACHESIZE} = $1;
+						if ($l2cachesection && $l2cacheline =~ /Installed\sSize:\s*([0-9]+)/i){
+							$current->{L2CACHESIZE} = $1;
+						}
 					}
 				}
-			}
 
-			$common->addCPU($current);
-			$cpucount++;
+				$common->addCPU($current);
+				$cpucount++;
+			}
 
 			undef $current;
 			undef $l2cacheid;

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
@@ -90,9 +90,10 @@ sub run {
 				$current->{MANUFACTURER} =~ s/CentaurHauls/VIA/;
 			}
 
-			$current->{TYPE} = $1 if /^model\sname\s*:\s*(.+)/i;
 			$current->{CORES} = $1 if /^siblings\s*:\s*(\d+)/i;
-			$current->{CURRENT_SPEED} = $1 if /^cpu\sMHz\s*:\s*(\d+)/i;
+			$current->{SPEED} = $current->{CURRENT_SPEED} = $1 if /^cpu\sMHz\s*:\s*(\d+)/i;
+			$current->{TYPE} = $1 if /^model\sname\s*:\s*(.+)/i;
+			$current->{HPT} = 'yes' if /^flags\s*:.*\bht\b/i;
 			$index = $1 if /^physical\sid\s*:\s*(\d+)/i;
 
 			if (/^\s*$/ && defined $index) {

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Archs/i386/CPU.pm
@@ -3,6 +3,7 @@ package Ocsinventory::Agent::Backend::OS::Linux::Archs::i386::CPU;
 use strict;
 
 use Config;
+use Data::Dumper;
 
 sub check { can_read("/proc/cpuinfo"); can_run("arch"); }
 
@@ -30,6 +31,7 @@ sub run {
 
 	# Prefer dmidecode to give us the information we're looking for
    	@cpu = `dmidecode -t processor`;
+
    	for (@cpu){
 		$current->{CORES} = $1 if /Core\sCount:\s*(\d+)/i;
 		$current->{CURRENT_SPEED} = $1 if /Current\sSpeed:\s*(\d+)/i;
@@ -72,8 +74,7 @@ sub run {
 				$cpucount++;
 			}
 
-			undef $current;
-			undef $l2cacheid;
+			$current = $l2cacheid = undef;
 		}
 	}
 
@@ -94,15 +95,16 @@ sub run {
 			$current->{SPEED} = $current->{CURRENT_SPEED} = $1 if /^cpu\sMHz\s*:\s*(\d+)/i;
 			$current->{TYPE} = $1 if /^model\sname\s*:\s*(.+)/i;
 			$current->{HPT} = 'yes' if /^flags\s*:.*\bht\b/i;
+			$index = $1 if ! defined $index && /^processor\s*:\s*(\d+)/i;
 			$index = $1 if /^physical\sid\s*:\s*(\d+)/i;
 
-			if (/^\s*$/ && defined $index) {
+			if (/^\s*$/) {
 				$current->{HPT} = 'no' if $current->{HPT} ne 'yes';
 				$current->{CPUARCH} = $cpuarch;
 				$current->{DATA_WIDTH} = $datawidth;
 				$current->{TYPE} =~ s/\s{2,}/ /g;
 				$cpu[$index] = $current;
-				undef $current;
+				$current = $index = undef;
 			}
 		}
 


### PR DESCRIPTION
I rewrote the code to use `dmidecode` exclusively if present/populated, otherwise fall back on `/proc/cpuinfo`. The parser now properly recognizes where one CPU/core ends and the next begins by matching an empty line, at which point it saves the CPU data and clears `$current` to avoid polluting the next iteration.

I only have Debian and Ubuntu servers running 64-bit Intel Xeon processors to test on, but both the `dmidecode` and `/proc/cpuinfo` fallback sections work as expected in that context.

A similar refactor should probably be imposed on the other CPU architectures, but I don't have the resources available to validate any modifications, so I'm not going to touch them.