### PR TITLE
Updated capacity to always report sizes in MB

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -196,9 +196,8 @@ sub run {
     			if (/^Serial\sNumber:\s*(.*)/i){
         			$serial = $1;	
 				}
-				if (/^User\sCapacity:\s*(.*)\sbytes/i){
+				if (/^User\sCapacity:\s*([0-9,]+)\sbytes/i){
 					$cap = $1;
-					$unit = $3;
 					$cap =~ s/,//g;
 					$cap = int($cap / 1000000)
 				}
@@ -216,6 +215,13 @@ sub run {
 				SERIAL => $serial,
 				TYPE => 'Disk',
 			});
+			undef $desc;
+			undef $cap;
+			undef $firmware;
+			undef $manufacturer;
+			undef $model;
+			undef $name;
+			undef $serial;
 		}
 	}
 }

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -59,7 +59,7 @@ sub getCapacity {
 	my ($dev) = @_;
   	my $cap;
   	chomp ($cap = `fdisk -s /dev/$dev 2>/dev/null`); #requires permissions on /dev/$dev
-  	$cap = int ($cap/1000) if $cap;
+  	$cap = int ($cap*1024/1000000) if $cap;
   	return $cap;
 }
 
@@ -196,19 +196,11 @@ sub run {
     			if (/^Serial\sNumber:\s*(.*)/i){
         			$serial = $1;	
 				}
-				if (/^User\sCapacity:\s*(.*)\sbytes\s\[(.*)\s(.*)\]/i){
+				if (/^User\sCapacity:\s*(.*)\sbytes/i){
 					$cap = $1;
 					$unit = $3;
 					$cap =~ s/,//g;
-					if ($unit eq "MB") {
-						$cap = int($cap/1024);
-					} elsif ($unit eq "GB") {
-						$cap = int($cap/1048576);
-					} elsif ($unit eq "TB") {
-						$cap = int($cap/1073741824);
-					} else { 
-						$cap = undef; 
-					}
+					$cap = int($cap / 1000000)
 				}
 				if (/^Firmware\sVersion:\s*(.*)/i){
 					$firmware = $1;

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -215,13 +215,7 @@ sub run {
 				SERIAL => $serial,
 				TYPE => 'Disk',
 			});
-			undef $desc;
-			undef $cap;
-			undef $firmware;
-			undef $manufacturer;
-			undef $model;
-			undef $name;
-			undef $serial;
+			$desc = $cap = $firmware = $manufacturer = $model = $name = $serial = undef;
 		}
 	}
 }


### PR DESCRIPTION
Previous code saved capacity as an integer but the meaning of the value would change depending on what unit `smartctl` reported in. For instance, `3,000,592,982,016 bytes [3.00 TB]` would correspond to a `DISKSIZE` value of 2795 while `256,060,514,304 bytes [256 GB]` would return 244198.

All sizes are now consistently converted to base-10 MB rather than base-2 MiB/GiB/whatever, mimicking the behaviour of `smartctl`.