### PR TITLE
Improved storage manufacturer detection

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -82,15 +82,19 @@ sub getDescription {
 
 sub getManufacturer {
   	my ($model) = @_;
-  	if($model =~ /(maxtor|western|sony|compaq|hewlett packard|ibm|seagate|toshiba|fujitsu|lg|samsung|nec|transcend)/i) {
-    	return ucfirst(lc($1));
+	if ($model =~ /^(IBM|LG|NEC)/) {
+		return $1;
+	} elsif($model =~ /^(maxtor|western digital|sony|compaq|hewlett[ -]packard|seagate|toshiba|fujitsu|samsung|transcend)/i) {
+		$model = lc($1);
+		$model =~ s/\b(\w)/\u$1/g;
+    	return $model;
   	} elsif ($model =~ /^HP/) {
-    	return "Hewlett Packard";
-  	} elsif ($model =~ /^WDC/) {
+    	return "Hewlett-Packard";
+  	} elsif ($model =~ /^WD/) {
     	return "Western Digital";
   	} elsif ($model =~ /^ST/) {
     	return "Seagate";
-  	} elsif ($model =~ /^HD/ or $model =~ /^IC/ or $model =~ /^HU/) {
+  	} elsif ($model =~ /^(HD|IC|HU)/) {
     	return "Hitachi";
   	}
 }
@@ -174,12 +178,15 @@ sub run {
 			for (@sm){
 				if (/^Model\sFamily:\s*(.*)/i){
         			$desc = $1;
-        			if ($desc =~ /(maxtor|western digital|sony|compaq|hewlett packard|ibm|seagate|toshiba|fujitsu|lg|samsung|nec|transcend)/i) {
+					if ($model =~ /^(IBM|LG|NEC)/) {
+						return $manufacturer = $1;
+					}
+        			elsif ($desc =~ /^(HP|Hewlett[ -]Packard)/) {
+            			$manufacturer = "Hewlett-Packard";
+        			}
+        			elsif ($desc =~ /^(maxtor|western digital|sony|compaq|seagate|toshiba|fujitsu|samsung|transcend)/i) {
             			$manufacturer = lc($1);
 						$manufacturer =~ s/\b(\w)/\u$1/g;
-        			}
-        			elsif ($desc =~ /^HP/) {
-            			$manufacturer = "Hewlett Packard";
         			}
         			elsif ($desc =~ /^WD/) {
             			$manufacturer = "Western Digital";

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -244,7 +244,7 @@ sub run {
 				MANUFACTURER => $manufacturer,
 				MODEL => $model,
 				NAME => $name,
-				SERIAL => $serial,
+				SERIALNUMBER => $serial,
 				TYPE => 'Disk',
 			});
 		}

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -173,25 +173,41 @@ sub run {
 		
 			for (@sm){
 				if (/^Model\sFamily:\s*(.*)/i){
-        			$manufacturer = $1;
-        			if ($manufacturer =~ /(maxtor|western|sony|compaq|hewlett packard|ibm|seagate|toshiba|fujitsu|lg|samsung|nec|transcend)/i){
-            			$desc=ucfirst(lc($1));
+        			$desc = $1;
+        			if ($desc =~ /(maxtor|western digital|sony|compaq|hewlett packard|ibm|seagate|toshiba|fujitsu|lg|samsung|nec|transcend)/i) {
+            			$manufacturer = lc($1);
+						$manufacturer =~ s/\b(\w)/\u$1/g;
         			}
-        			elsif ($manufacturer =~ /^HP/) {
-            			$desc="Hewlett Packard";
+        			elsif ($desc =~ /^HP/) {
+            			$manufacturer = "Hewlett Packard";
         			}
-        			elsif ($manufacturer =~ /^WDC/) {
-            			$desc="Western Digital";
+        			elsif ($desc =~ /^WD/) {
+            			$manufacturer = "Western Digital";
         			}
-        			elsif ($manufacturer =~ /^ST/) {
-            			$desc="Seagate";
+        			elsif ($desc =~ /^ST/) {
+            			$manufacturer = "Seagate";
         			}
-        			elsif ($manufacturer =~ /^HD/ or $manufacturer =~ /^IC/ or $manufacturer =~ /^HU/) {
-            			$desc="Hitachi";
+        			elsif ($desc =~ /^(HD|IC|HU)/) {
+            			$manufacturer = "Hitachi";
+					}
+					elsif ($desc =~ /^SandForce/) {
+						$manufacturer = "Corsair";
 					}
 				}
 				if (/^Device\sModel:\s*(.*)/i){
         			$model = $1;
+					if (!defined $manufacturer) {
+						if ($model =~ /^(hitachi|toshiba|samsung)/i) {
+							$manufacturer = lc($1);
+							$manufacturer =~ s/\b(\w)/\u$1/g;
+						}
+						elsif ($model =~ /^ST/) {
+							$manufacturer = 'Seagate';
+						}
+						elsif ($model =~ /^HD/) {
+							$manufacturer = 'Hitachi';
+						}
+					}
     			}
     			if (/^Serial\sNumber:\s*(.*)/i){
         			$serial = $1;	

--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Storages.pm
@@ -66,7 +66,7 @@ sub run {
 
       $devices->{$storage->{'_name'}} = {
         NAME => $storage->{'name'},
-        SERIAL => $storage->{'device_serial'},
+        SERIALNUMBER => $storage->{'device_serial'},
         DISKSIZE => $size,
         FIRMWARE => $storage->{'device_revision'},
         MANUFACTURER => $manufacturer,
@@ -99,7 +99,7 @@ sub run {
       
       $devices->{$storage->{'_name'}} = {
         NAME => $storage->{'_name'},
-        SERIAL => $storage->{'device_serial'},
+        SERIALNUMBER => $storage->{'device_serial'},
         DISKSIZE => $size,
         FIRMWARE => $storage->{'device_revision'},
         MANUFACTURER => $manufacturer,


### PR DESCRIPTION
The following device types failed to identify their manufacturers. These account for 147 of my 467 inventoried storage devices.

```
Device Model:     ST2000DM001-1ER164
Serial Number:    XXXXXXXX
LU WWN Device Id: 5 000c50 079584f5b
Firmware Version: CC25
User Capacity:    2,000,398,934,016 bytes [2.00 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   9
ATA Standard is:  Not recognized. Minor revision code: 0x001f
Local Time is:    Thu Aug 27 12:58:49 2015 EDT
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
```

```
Device Model:     TOSHIBA DT01ACA100
Serial Number:    XXXXXXXXX
LU WWN Device Id: 5 000039 ff2eab0d5
Firmware Version: MS2OA750
User Capacity:    1,000,204,886,016 bytes [1.00 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   8
ATA Standard is:  ATA-8-ACS revision 4
Local Time is:    Thu Aug 27 12:59:44 2015 EDT
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
```

```
Device Model:     Hitachi HDS721050CLA360
Serial Number:    XXXXXXXXXXXXXX
LU WWN Device Id: 5 000cca 39dc8b5c8
Firmware Version: JP2OA50E
User Capacity:    500,107,862,016 bytes [500 GB]
Sector Size:      512 bytes logical/physical
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   8
ATA Standard is:  ATA-8-ACS revision 4
Local Time is:    Thu Aug 27 13:00:26 2015 EDT
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
```

```
Device Model:     Samsung SSD 850 PRO 256GB
Serial Number:    XXXXXXXXXXXXXXX
LU WWN Device Id: 5 002538 8a081e496
Firmware Version: EXM01B6Q
User Capacity:    256,060,514,304 bytes [256 GB]
Sector Size:      512 bytes logical/physical
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   8
ATA Standard is:  ATA-8-ACS revision 4c
Local Time is:    Thu Aug 27 17:11:28 2015 UTC
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
```

```
Model Family:     SandForce Driven SSDs
Device Model:     Corsair Force GT
Serial Number:    XXXXXXXXXXXXXXXXXXXX
LU WWN Device Id: 0 000000 000000000
Firmware Version: 5.02
User Capacity:    120,034,123,776 bytes [120 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Device is:        In smartctl database [for details use: -P show]
ATA Version is:   ATA8-ACS, ACS-2 T13/2015-D revision 3
SATA Version is:  SATA 3.0, 6.0 Gb/s (current: 3.0 Gb/s)
Local Time is:    Thu Aug 27 13:03:01 2015 EDT
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
```

Committed a fix that falls back on "Device Model" matching if "Model Family" is not available. It also swaps the role of the "manufacturer" and "description" fields for Linux systems. For instance, some inventoried drives list manufacturer "Seagate Barracuda 7200.10" and description "Seagate". Finally, I tweaked the regex matching to properly handle names that should actually be reported in all caps, ie. IBM, LG, and NEC.