### PR TITLE
Add info in PUBLISHER field when getting the list of installed softwares on Debian.

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
@@ -11,8 +11,8 @@ sub run {
   my $size;
   
 # use dpkg-query --show --showformat='${Package}|||${Version}\n'
-  foreach(`dpkg-query --show --showformat='\${Package}---\${Version}---\${Installed-Size}---\${Description}\n'`) {
-     if (/^(\S+)---(\S+)---(\S*)---(.*)/) {
+  foreach(`dpkg-query --show --showformat='\${Package}---\${Version}---\${Installed-Size}---\${Homepage}---\${Description}\n'`) {
+     if (/^(\S+)---(\S+)---(\S*)---(\S*)---(.*)/) {
        if ($3) { 
 	$size=$3;
        } else {
@@ -22,7 +22,8 @@ sub run {
          'NAME'          => $1,
          'VERSION'       => $2,
          'FILESIZE'      => $size,
-         'COMMENTS'      => $4,
+         'PUBLISHER'     => $4,
+         'COMMENTS'      => $5,
          'FROM'          => 'deb'
        });
     }


### PR DESCRIPTION
The Unix OCSI agent doesn't currently return any info about the upstream project of its installed softwares (while it does on Windows).

Knowing the upstream project of a software might help in precisely identifying a software,
which might help in, for example, finding a corresponding CPE entry in NIST's CPE dictionary.

This pull request provides an improvement by filling the PUBLISHER field with the "{Homepage}" info fro m dpkg-query.

It should be 'a good thing' to have the same change for rpm packages,... but I have no such platform
to test the change here atm.

Br,

Cyrille