### PR TITLE
lower DNS Resolution Sleep from 1 to 0.01 seconds

### DIFF
--- a/resources/ipdiscover/ipdiscover.h
+++ b/resources/ipdiscover/ipdiscover.h
@@ -40,7 +40,7 @@
 #endif
 
 #define VERSION 5
-#define NAME_RES_LATENCY 1000000
+#define NAME_RES_LATENCY 10000
 #define REQUEST_LATENCY_DEFAULT 100000
 
 /* Trame ARP */


### PR DESCRIPTION
Hi,

Ipdiscover takes very long on a Class B Net. I lowered the hardcoded DNS Resolution Latency to get the Results in 5 Minutes instead of waiting 1 Day.

Maybe using a new Parameter for that would be better, but that would be a too deep dive in the Project for me :)

Best Regards,
atze234