### PR TITLE
centos-release is the correct file to check

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/CentOS.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/CentOS.pm
@@ -2,18 +2,14 @@ package Ocsinventory::Agent::Backend::OS::Linux::Distro::NonLSB::CentOS;
 use strict;
 
 sub check {
-    -f "/etc/redhat-release"
-      &&
-    !readlink ("/etc/redhat-release")
-      &&
-    !-f "/etc/vmware-release"
+    -f "/etc/centos-release"
 }
 
 ####
 sub findRelease {
   my $v;
 
-  open V, "</etc/redhat-release" or warn;
+  open V, "</etc/centos-release" or warn;
   chomp ($v=<V>);
   close V;
   $v;


### PR DESCRIPTION
On CentOS 6.8 and newer, the redhat-release file is just a symlink for centos-release, which means the check function does not match and the osname of these releases reports as "Linux".

Older releases still matches in the Redhat.pm file and will report correct osname from it.