### PR TITLE
Add uuid for devide id generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
     - To enhance SNMP feature with custom networks scans, you need these modules:
       - Net::Netmask
       - Net::Ping or Nmap::Parser
+    - Data::UUID is used to create a unique id for every machine.
       
   ####The following commands are needed:
     - dmidecode on Linux and *BSD (i386, amd64, ia64) => dmidecode is required to read the BIOS stats.

--- a/lib/Ocsinventory/Agent.pm
+++ b/lib/Ocsinventory/Agent.pm
@@ -183,7 +183,7 @@ sub run {
     chomp(my $hostname = `uname -n| cut -d . -f 1`);
     if ((!$config->{config}{deviceid}) || $config->{config}{deviceid} !~ /\Q$hostname\E-(?:\w{8})(?:-\w{4}){3}(?:-\w{12})/) {
 
-	$ug = Data::UUID->new;
+	my $ug = Data::UUID->new;
 
         $config->{config}{old_deviceid} = $config->{config}{deviceid};
         $config->{config}{deviceid} =sprintf "%s-%s", $hostname, $ug->to_string($ug->create_from_name_str(NameSpace_URL, $hostname ));


### PR DESCRIPTION
I change how the device id is created because in the old way i can have collisions (i experienced a lot of this into a client). So, to solve this problem i change the device_id to receive a uuid instead of the date.