### PR TITLE
Used Parse::EDID for reading EDID info (Cyrille)

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Video.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Video.pm
@@ -1,6 +1,7 @@
 package Ocsinventory::Agent::Backend::OS::MacOS::Video;
 use strict;
 
+use Parse::EDID qw(parse_edid);
 
 sub check {
     my $params = shift;
@@ -31,11 +32,11 @@ sub run {
 
    #Getting monitor serial number
    #TODO: get serial for multiples monitors
-   my $ioreg = `ioreg -lw0 | grep "EDID" | sed "/[^<]*</s///" | xxd -p -r | strings -7`;
-   $ioreg =~ /(.*)\n(.*)/;
+   my $ioreg_binary = `ioreg -lw0 | grep "EDID" | sed "/[^<]*</s///" | xxd -p -r`;
+   my $ioreg = parse_edid($ioreg_binary);
 
-   my $ioreg_serial = $1; chomp $ioreg_serial; 
-   my $ioreg_name = $2; chomp $ioreg_name;
+   my $ioreg_serial = $ioreg->{'monitor_name'};
+   my $ioreg_name = $ioreg->{'serial_number2'};
 
     # add the video information
     foreach my $video (@$data){

--- a/tools/macosx/scripts/create-darwin-perl-lib_fromCPAN.pl
+++ b/tools/macosx/scripts/create-darwin-perl-lib_fromCPAN.pl
@@ -108,6 +108,7 @@ Compress::Zlib
 Compress::Raw::Zlib
 IO::Zlib
 Mac::SysProfile
+Parse::EDID
 .
 
 # push all the dep's into a @missing array


### PR DESCRIPTION
This commit fixes https://github.com/OCSInventory-NG/UnixAgent/issues/51

Note though that the xcode project file should also be updated, but I intend to do that in https://github.com/OCSInventory-NG/UnixAgent/pull/49