### PR TITLE
List packages without installed size metadata

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
@@ -12,7 +12,7 @@ sub run {
   
 # use dpkg-query --show --showformat='${Package}|||${Version}\n'
   foreach(`dpkg-query --show --showformat='\${Package}---\${Version}---\${Installed-Size}---\${Description}\n'`) {
-     if (/^(\S+)---(\S+)---(\S+)---(.*)/) { 
+     if (/^(\S+)---(\S+)---(\S*)---(.*)/) { 
        if ($3) { 
 	$size=$3;
        } else {


### PR DESCRIPTION
Correct regular expression to accept and capture empty string Installed-Size

Really fix bug #1032393
https://bugs.launchpad.net/ocsinventory-unix-agent/+bug/1032393

When installed size is not in metadata, this package is omitted by not matching regular expression.
Current code only display 'Unknown size' if package installed size metadata is 0.