### PR TITLE
Added support for Solaris 11 and new Oracle Hardware

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/BSDpkg.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/BSDpkg.pm
@@ -3,6 +3,7 @@ package Ocsinventory::Agent::Backend::OS::Generic::Packaging::BSDpkg;
 sub check {
     my $params = shift;
     my $common = $params->{common};
+    return if ( `uname -rs` =~ /SunOS 5.11/ );
     $common->can_run("pkg") || $common->can_run("pkg_info")
 }
 

--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/CPU.pm
@@ -27,34 +27,37 @@ sub run {
   my $cpu_slot;
   my $cpu_speed;
   my $cpu_type;
-  my $OSLevel;
   my $model;
   my $zone;
   my $sun_class_cpu=0;
+  my $cpusocket=1;
+  my $cpu_arch;
+  my $cpu_manufacturer;
+  my $data_width;
+  my %coretable = ( 'dual', 2, 'quad', 4, 'six', 6, 'eight', 8, 'ten', 10, 'twelve', 12 );
+  my $aarch;
+
   
-  $OSLevel=`uname -r`;
-      
-  
-  if ( $OSLevel =~ /5.8/ || !$common->can_run("zoneadm")){
+  chomp($aarch = `uname -p`);
+  chomp($cpu_arch = `uname -m`);
+  chomp($data_width = `isainfo -b`);
+
+  if ( !$common->can_run("zonename") || `zonename` =~ /global/ ) {
+    # Either pre Sol10 or in Sol10/Sol11 global zone
     $zone = "global";
-  }else{
-      foreach (`zoneadm list -p`){
-        $zone=$1 if /^0:([a-z]+):.*$/;
-      } 
+  } else {
+    # Sol10/Sol11 local zone
+    $zone = "";
   }
-  
-  if ($zone)
-  {  
-  # first, we need determinate on which model of Sun Server we run,
-  # because prtdiags output (and with that memconfs output) is differend
-  # from server model to server model
-  # we try to classified our box in one of the known classes
-    $model=`uname -i`;
-  # debug print model  
-  # cut the CR from string model
-    $model = substr($model, 0, length($model)-1);
-  }else{
-    $model="Solaris Containers";
+ 
+  if ($zone) {
+    if ( $aarch =~ /sparc/ && $common->can_run("virtinfo") && `virtinfo -t` =~ /.*LDoms guest.*/ ) {
+      $model = "Solaris Ldom";
+    } else {
+      chomp($model = `uname -i`);
+    }
+  } else {
+    $model = "Solaris Containers";
   }
   
   #print "CPU Model: $model\n";
@@ -92,8 +95,14 @@ sub run {
   if ($model  =~ /Solaris Containers/){ $sun_class_cpu = 6; } 
   if ($model  =~ /SUNW,SPARCstation/) { $sun_class_cpu = 7; }
   if ($model  =~ /SUNW,Sun-Blade-100/) { $sun_class_cpu = 7; }
+  if ($model  =~ /SUNW,Sun-Blade-1500/) { $sun_class_cpu = 7; }
   if ($model  =~ /SUNW,Ultra/) { $sun_class_cpu = 7; }
   if ($model =~ /FJSV,GPUZC-M/) { $sun_class_cpu = 8; }
+  # Recent and current hardware
+  if ($model =~ /SUNW,T5/) { $sun_class_cpu = 20; }     # T5240, T5440
+  if ($model =~ /i86pc/)   { $sun_class_cpu = 21; }     # Solaris Intel
+  if ($model =~ /sun4v/)   { $sun_class_cpu = 22; }     # T3-x, T4-x, T5-x
+  if ($model =~ /Solaris Ldom/){ $sun_class_cpu = 23; }
 
 
 
@@ -112,6 +121,7 @@ sub run {
     }
   }
 
+
   if($sun_class_cpu == 1)
   {
 
@@ -120,6 +130,7 @@ sub run {
     {
       if(/^Sun Microsystems, Inc. Sun Fire\s+\S+\s+\((\d+)\s+X\s+(\S+)\s+(\d+)/)
       {
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
         $cpu_slot = $1;
         $cpu_type = $2;
         $cpu_speed = $3;
@@ -129,6 +140,7 @@ sub run {
         
       elsif (/^Sun Microsystems, Inc. Sun Fire\s+\S+\s+\((\S+)\s+(\d+)/)
       {
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
           $cpu_slot="1";
           $cpu_type=$1;
           $cpu_speed=$2;
@@ -147,6 +159,7 @@ sub run {
     {
       if(/^Sun Microsystems, Inc. Sun Fire\s+\S+\s+\((\d+)\s+X\s+(\S+)\s+(\S+)\s+(\d+)/)     
       {
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
         $cpu_slot = $1;
         $cpu_type = $3 . " (" . $2 . ")";
         $cpu_speed = $4;
@@ -155,6 +168,7 @@ sub run {
       }
       elsif (/^Sun Microsystems, Inc. Sun Fire\s+V\S+\s+\((\d+)\s+X\s+(\S+)\s+(\d+)(\S+)/)
     {
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
         $cpu_slot = $1;
         $cpu_type = $2 . " (" . $1 . ")";
         $cpu_speed = $3;
@@ -164,6 +178,7 @@ sub run {
       #    Sun Microsystems, Inc. Sun Fire V240 (UltraSPARC-IIIi 1002MHz)
       elsif (/^Sun Microsystems, Inc. Sun Fire\s+\S+\s+\((\S+)\s+(\d+)/)
       {
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
           $cpu_slot="1";
           $cpu_type=$1;
           $cpu_speed=$2;
@@ -180,14 +195,15 @@ sub run {
     {
     #Sun Microsystems, Inc. Sun-Fire-T200 (Sun Fire T2000) (8-core quad-thread UltraSPARC-T1 1000MHz)
     #Sun Microsystems, Inc. Sun-Fire-T200 (Sun Fire T2000) (4-core quad-thread UltraSPARC-T1 1000MHz)
-      if(/^Sun Microsystems, Inc.\s+\S+\s+\(\S+\s+\S+\s+\S+\)\s+\((\d+).*\s+(\S+)\s+(\S+)\s+(\d+)/)
+      if(/^Sun Microsystems, Inc.\s+\S+\s+\(\S+\s+\S+\s+\S+\)\s+\((\d+).*\s+(\S+)-\S+\s+(\S+)\s+(\d+)/)
       {
-        # T2000 has only one cCPU
-        $cpu_slot = $1;
-        $cpu_type = $3 . " (" . $1 . " " . $2 . ")";
+        # T2000 has only one CPU
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
+        $cpu_slot = 1;
+        $cpu_type = "$3 ($1-Core $2-Thread)";
         $cpu_speed = $4;
         $cpu_core=$1;
-        $cpu_thread=$2;
+	$cpu_thread = $coretable{lc($2)};
       }
     }
   }
@@ -200,13 +216,15 @@ sub run {
     
       #Sun Microsystems, Inc. SPARC Enterprise T5120 (8-core 8-thread UltraSPARC-T2 1165MHz)
       #Sun Microsystems, Inc. SPARC Enterprise T5120 (4-core 8-thread UltraSPARC-T2 1165MHz)
-      if(/^Sun Microsystems, Inc\..+\((\d+)*(\S+)\s+(\d+)*(\S+)\s+(\S+)\s+(\d+)MHz\)/)
+      #Oracle Corporation SPARC Enterprise T5220 (8-Core 8-Thread UltraSPARC-T2 1415MHz)
+      if(/^(.*)\s+SPARC.+\((\d+)*(\S+)\s+(\d+)*(\S+)\s+(\S+)\s+(\d+)MHz\)/)
       {
-        $cpu_slot = $1;
-        $cpu_type = $1 . " (" . $3 . "" . $4 . ")";
-        $cpu_speed = $6;
-    $cpu_core=$1;
-    $cpu_thread=$3;
+        $cpu_manufacturer = $1;
+        $cpu_slot = 1;
+        $cpu_type = "$6 ($2-Core $4-Thread)";
+        $cpu_speed = $7;
+    $cpu_core=$2;
+    $cpu_thread=$4;
         
       }
     }
@@ -217,23 +235,27 @@ sub run {
     foreach (`memconf 2>&1`)
     {
       #Sun Microsystems, Inc. Sun SPARC Enterprise M5000 Server (6 X dual-core dual-thread SPARC64-VI 2150MHz)
-      
+      #Sun Microsystems, Inc. SPARC Enterprise M8000 Server (2 X Quad-Core Dual-Thread SPARC64-VII 2520MHz)
+
       #Fujitsu SPARC Enterprise M4000 Server (4 X dual-core dual-thread SPARC64-VI 2150MHz)
-      if(/^Sun Microsystems, Inc\..+\((\d+)\s+X\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+)/)
+      if(/^Sun Microsystems, Inc\..+\((\d+)\s+X\s+(\S+)-\S+\s+(\S+)-\S+\s+(\S+)\s+(\d+)/)
       {
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
         $cpu_slot = $1;
-        $cpu_type = $3 . " (" . $1 . " " . $2 . ")";
+        $cpu_type = "$4 ($2-Core $3-Thread)";
         $cpu_speed = $5;
-    $cpu_core=$1." ".$2;
-    $cpu_thread=$3;
+        $cpu_core = $coretable{lc($2)};
+	$cpu_thread = $coretable{lc($3)};
       }
-      if(/^Fujitsu SPARC Enterprise.*\((\d+)\s+X\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+)/)
+      #Fujitsu SPARC Enterprise M4000 Server (4 X dual-core dual-thread SPARC64-VI 2150MHz)
+      if(/^Fujitsu SPARC Enterprise.*\((\d+)\s+X\s+(\S+)-\S+\s+(\S+)-\S+\s+(\S+)\s+(\d+)/) 
       {
+        $cpu_manufacturer = "Fujitsu";
         $cpu_slot = $1;
-        $cpu_type = $3 . " (" . $1 . " " . $2 . ")";
+        $cpu_type = "$4 ($2-Core $3-Thread)";
         $cpu_speed = $5;
-        $cpu_core=$1." ".$2;
-        $cpu_thread=$3;
+        $cpu_core = $coretable{lc($2)};
+	$cpu_thread = $coretable{lc($3)};
       }
       
     }
@@ -242,30 +264,25 @@ sub run {
   
   if($sun_class_cpu == 6)
   {
+    $cpu_manufacturer = "Solaris Container";
     foreach (`prctl -n zone.cpu-shares $$`)
     {
         $cpu_type = $1 if /^zone.(\S+)$/;        
         $cpu_type = $cpu_type." ".$1 if /^\s*privileged+\s*(\d+).*$/;
-        #$cpu_slot = 1 if /^\s*privileged+\s*(\d+).*$/;
-        foreach (`memconf 2>&1`)
-        {
-            if(/^.*\s+\((\d+).*\s+(\d+)MHz.*$/)
-            {        
-                $cpu_slot = $1;
-                $cpu_speed = $2;
-            }
-        }
+        $cpu_slot = 1 if /^\s*privileged+\s*(\d+).*$/;
     }    
   }
 
   if($sun_class_cpu == 7) {
     foreach(`memconf 2>&1`) {
+      #Sun Microsystems, Inc. Sun Blade 1500 (UltraSPARC-IIIi 1062MHz)
       #Sun Microsystems, Inc. Sun Blade 100 (UltraSPARC-IIe 502MHz)
       #Sun Microsystems, Inc. Sun Ultra 5/10 UPA/PCI (UltraSPARC-IIi 333MHz)
       #Sun Microsystems, Inc. Sun Ultra 1 SBus (UltraSPARC 143MHz)
       #Sun Microsystems, Inc. SPARCstation 20 (1 X 390Z50) (SuperSPARC 50MHz)
       #Sun Microsystems, Inc. SPARCstation 5 (TurboSPARC-II 170MHz)
       if (/^Sun Microsystems, Inc\..+\((\S+)\s+(\d+)MHz\)/) {
+        $cpu_manufacturer = "Sun Microsystems, Inc.";
         $cpu_slot = 1;
         $cpu_type = $1;
         $cpu_speed = $2;
@@ -280,6 +297,7 @@ sub run {
     #Fujitsu PRIMEPOWER450 4x SPARC64 V clone (4 X SPARC64-V 1978MHz)
     #Fujitsu PRIMEPOWER250 2x SPARC64 V clone (2 X SPARC64-V 1649MHz)
     if (/^FJSV,GPUZC-M.+\((\d+)\s+X\s+(\S+)\s+(\d+)MHz\)/) {
+           $cpu_manufacturer = "Fujitsu";
            $cpu_slot = $1;
            $cpu_type = $2;
            $cpu_speed = $3;
@@ -288,24 +306,134 @@ sub run {
       }
     }
   }
-    
+   
+  if ($sun_class_cpu == 20) {
+    foreach (`memconf 2>&1`) {
+      #Oracle Corporation T5240 (2 X 8-Core 8-Thread UltraSPARC-T2+ 1582MHz)
+      #Oracle Corporation T5440 (4 X 8-Core 8-Thread UltraSPARC-T2+ 1596MHz)
+      #Sun Microsystems, Inc. T5240 (2 X 8-Core 8-Thread UltraSPARC-T2+ 1582MHz)
+      if(/^(.*)\s+T\d+\s+\((\d+)\s+X\s+(\d+)-\S+\s+(\d)+-\S+\s+(\S+)\s+(\d+)MHz\)/) {
+        $cpu_manufacturer = $1;
+        $cpu_slot = $2;
+        $cpu_type = "$5 ($3-Core $4-Thread)";
+        $cpu_speed = $6;
+        $cpu_core = $3;
+        $cpu_thread = $4;
+      }
+    }
+  }
+
+  if ($sun_class_cpu == 21) {
+    foreach (`memconf 2>&1`) {
+      # Solaris on x86
+      #Oracle Corporation Sun Fire X4270 Server (2 X Quad-Core Hyper-Threaded Intel(R) Xeon(R) X5570 @ 2.93GHz)
+      #HP ProLiant DL380 G5 (2 X Quad-Core Intel(R) Xeon(R) E5430 @ 2.66GHz)
+      #HP ProLiant DL380 G7 (2 X Six-Core Hyper-Threaded Intel(R) Xeon(R) X5670 @ 2.93GHz)
+      #HP ProLiant DL580 G7 (4 X Ten-Core Hyper-Threaded Intel(R) Xeon(R) E7- 4860 @ 2.27GHz)
+      #HP ProLiant DL380p Gen8 (2 X Eight-Core Hyper-Threaded Intel(R) Xeon(R) E5-2660 0 @ 2.20GHz Proc 2)
+      #HP ProLiant DL380 Gen9 (2 X Twelve-Core Hyper-Threaded Intel(R) Xeon(R) E5-2680 v3 @ 2.50GHz Proc 2 2497MHz)
+      if(/^.*\((\d+) X (\S+)-Core Hyper-Threaded (\S+)(.*) @ (\S+)GHz.*\)/) {
+        # Hyper-Threaded CPU
+        $cpu_manufacturer = $3;
+        $cpu_slot = $1;
+        $cpu_type = $3 . $4;
+        $cpu_speed = $5 * 1000;
+        $cpu_core = $coretable{lc($2)};
+        $cpu_thread = "on";
+      }
+      elsif(/^.*\((\d+) X (\S+)-Core (\S+)(.*) @ (\S+)GHz.*\)/) {
+        # Non Hyper-Threaded CPU
+        $cpu_manufacturer = $3;
+        $cpu_slot = $1;
+        $cpu_type = $3 . $4;
+        $cpu_speed = $5 * 1000;
+        $cpu_core = $coretable{lc($2)};
+        $cpu_thread = "off";
+      }
+      elsif(/^.*\((\S+)-Core (\S+)(.*) @ (\S+)GHz.*\)/) {
+       # single core CPU
+        $cpu_manufacturer = $2;
+        $cpu_slot = 1;
+        $cpu_type = $2 . $3;
+        $cpu_speed = $4 * 1000;
+        $cpu_core = $coretable{lc($1)};
+        $cpu_thread = "off";
+      }
+    }
+  }
+
+  if ($sun_class_cpu == 22) {
+    foreach (`memconf 2>&1`) {
+      #Oracle Corporation SPARC T3-1 (16-Core 8-Thread SPARC-T3 1649MHz)
+      #Oracle Corporation SPARC T3-2 (2 X 16-Core 8-Thread SPARC-T3 1649MHz)
+      #Oracle Corporation SPARC T4-1 (8-Core 8-Thread SPARC-T4 2848MHz)
+      #Oracle Corporation SPARC T4-2 (2 X 8-Core 8-Thread SPARC-T4 2848MHz)
+      #Oracle Corporation SPARC T4-4 (4 X 8-Core 8-Thread SPARC-T4 2998MHz)
+      #Oracle Corporation SPARC T5-2 (16-Core 8-Thread SPARC-T5 3600MHz)
+      #Oracle Corporation SPARC T5-4 (4 X 16-Core 8-Thread SPARC-T5 3600MHz)
+      if(/^Oracle Corporation.+\((\d+)-Core (\d+)-Thread (\S+) (\d+)MHz\)/) {
+        # Single CPU string
+        $cpu_manufacturer = "Oracle Corporation";
+        $cpu_slot = 1;
+        $cpu_type = "$3 ($1-Core $2-Thread)";
+        $cpu_speed = $4;
+        $cpu_core = $1;
+        $cpu_thread = $2;
+      }
+      elsif(/^Oracle Corporation.+\((\d+) X (\d+)-Core (\d+)-Thread (\S+) (\d+)MHz\)/) {
+        # Multiple CPU string
+        $cpu_manufacturer = "Oracle Corporation";
+        $cpu_slot = $1;
+        $cpu_type = "$4 ($2-Core $3-Thread)";
+        $cpu_speed = $5;
+        $cpu_core = $2;
+        $cpu_thread = $3;
+      }
+    }
+  }
+
+  if($sun_class_cpu == 23)
+  {
+  # Solaris LDom support
+    $cpu_slot=1;
+    $cpu_core = 0;
+    $cpu_thread = 0;
+    $cpu_manufacturer = "Solaris LDom";
+    foreach (`psrinfo -pv`) {
+      if (/^The physical processor has.* (\d+) virtual processors.*/) {
+        $cpu_thread = $cpu_thread + $1;
+      }
+      elsif (/^\s+(\S+)\s+\(.*clock\s+(\d+)\sMHz\)/) {
+        $cpu_type = $1;
+        $cpu_speed = $2;
+      }
+    }
+  }
+ 
   # for debug only
   #print "cpu_slot: " . $cpu_slot . "\n";
   #print "cpu_type: " . $cpu_type . "\n";
   #print "cpu_speed: " . $cpu_speed . "\n";
   #print "cpu_core: " . $cpu_core . "\n";
   #print "cpu_thread: " . $cpu_thread . "\n";
-  
-  $current->{MANUFACTURER} = "SPARC" ;
-  $current->{SPEED} = $cpu_speed if $cpu_speed;
-  $current->{TYPE} = $cpu_type if $cpu_type;
-  $current->{NUMBER} = $cpu_slot if $cpu_slot;
-  $current->{CORE} = $cpu_core if $cpu_core;
-  $current->{THREAD} = $cpu_thread if $cpu_thread;
-  $common->addCPU($current);
-  
-  
-  
+ 
+  # Finally, add the found CPUs
+  for $cpusocket ( 1 .. $cpu_slot ) {
+    $current->{MANUFACTURER} = $cpu_manufacturer if $cpu_manufacturer;
+    $current->{SPEED} = $cpu_speed if $cpu_speed;
+    $current->{CURRENT_SPEED} = $cpu_speed if $cpu_speed;
+    $current->{TYPE} = $cpu_type if $cpu_type;
+    $current->{CORES} = $cpu_core if $cpu_core;
+    $current->{CPUARCH} = $cpu_arch if $cpu_arch;
+    if ( $cpu_core == 0 ) {
+      $current->{LOGICAL_CPUS} = $cpu_thread if ( $cpu_thread );
+    } else {
+      $current->{LOGICAL_CPUS} = $cpu_core * $cpu_thread if ( $cpu_core && $cpu_thread );
+    }
+    $current->{DATA_WIDTH} = $data_width if $data_width;
+    $common->addCPU($current);
+  }
+ 
   # insert to values we have found
   # $common->setHardware({
   #   PROCESSORT => $cpu_type,

--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/Controllers.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/Controllers.pm
@@ -13,10 +13,11 @@ sub run {
 
     my $name;
     my $type;
-    my $manufacturer;
+    my $description;
 
     foreach(`cfgadm -s cols=ap_id:type:info`){
-        next if (/^Ap_Id/);     
+        $name = $type = $description = "";
+	next if (/^Ap_Id/);     
         if (/^(\S+)\s+/){
             $name = $1;
         }
@@ -24,13 +25,13 @@ sub run {
             $type = $1;
         }
         #No manufacturer, but informations about controller
-        if (/^\S+\s+\S+\s+(\S+)/){
-            $manufacturer = $1;
-        }               
+        if(/^\S+\s+\S+\s+(.*)/){
+            $description = $1;
+        }
         $common->addController({
             'NAME'          => $name,
-            'MANUFACTURER'  => $manufacturer,
             'TYPE'          => $type,
+            'DESCRIPTION'   => $description,
         });
     }
 }

--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/Drives.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/Drives.pm
@@ -9,10 +9,10 @@ package Ocsinventory::Agent::Backend::OS::Solaris::Drives;
 
 
 use strict;
-sub check { 
-    my $params = shift;
-    my $common = $params->{common};
-    $common->can_run ("df"); 
+sub check {
+  my $params = shift;
+  my $common = $params->{common};
+  $common->can_run ("df")
 }
 
 sub run {
@@ -28,23 +28,25 @@ sub run {
 #Looking for mount points and disk space 
     for (`df -k`){
         if (/^Filesystem\s*/){next};
-        # on Solaris 10 /devices is an extra mount which we like to exclude
+        # on Solaris 10 and up, /devices is an extra mount which we like to exclude
         if (/^\/devices/){next};
-        # on Solaris 10 /platform/.../libc_psr_hwcap1.so.1 is an extra mount which we like to exclude
+        # on Solaris 10 and up, /platform/.../libc_psr_hwcap1.so.1 is an extra mount which we like to exclude
         if (/^\/platform/){next};
         # exclude cdrom mount point
         if (/^\/.*\/cdrom/){next};
-        if (!(/^\/.*/) && !(/^swap.*/)){next};
-        if (/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\n/){    
-            $filesystem = $1;
-            $total = sprintf("%i",($2/1024));    
+        if (/^swap.*/){next};
+        # exclude special entries such as ctfs, proc, mnttab, etc...
+        if (/^.*\s+0\s+0\s+0.*/){next};
+        # skip nfs (dirty hack)
+        if (/^\S+:\/.*/){next};
+        # everything else is a local filesystem
+        if (/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\n/){
+            $filesystem = $6;
+            $total = sprintf("%i",($2/1024));
             $free = sprintf("%i",($4/1024));
-            $volumn = $6;
-            if ($filesystem =~ /^\/dev\/\S*/){     
-                chomp($type=`fstyp $filesystem`);
-                $type = '' if $type =~ /cannot stat/;
-            } else {$type="";}     
-            #print "FILESYS ".$filesystem." FILETYP ".$type." TOTAL ".$total." FREE ".$free." VOLUMN ".$volumn."\n";
+            $volumn = $1;
+            chomp($type = `mount -v | grep  " $filesystem "`);
+            $type =~ s/\S+\s+on\s+\S+\s+type\s+(\S+)\s+.*/$1/;
             $common->addDrive({
                 FREE => $free,
                 FILESYSTEM => $filesystem,

--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/Ports.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/Ports.pm
@@ -1,0 +1,68 @@
+package Ocsinventory::Agent::Backend::OS::Solaris::Ports;
+
+use strict;
+
+sub run {
+  my $params = shift;
+  my $common = $params->{common};
+
+  my $zone;
+  my $SystemModel;
+  my $aarch;
+
+  my $flag;
+  my $caption;
+  my $description;
+  my $name;
+  my $type;
+
+  if ( !$common->can_run("zonename") || `zonename` =~ /global/ ) {
+    # Ether pre Sol10 or in Sol10/Sol11 global zone
+    $zone = "global";
+  } else {
+    $zone = "";
+  }
+
+  if ($zone) {
+    chomp($SystemModel = `uname -m`);
+    chomp($aarch = `uname -p`);
+    if( $aarch eq "i386" ){
+      #
+      # For a Intel/AMD arch, we're using smbios
+      #
+      foreach(`/usr/sbin/smbios -t SMB_TYPE_PORT`) {
+        if(/\s+Internal Reference Designator:\s*(.+)/i ) {
+          $flag = 1;
+          $name = $1;
+        }
+        elsif ($flag && /^$/) { # end of section
+          $flag = 0;
+
+          $common->addPorts({
+            CAPTION => $caption,
+            DESCRIPTION => $description,
+            NAME => $name,
+            TYPE => $type,
+          });
+
+          $caption = $description = $name = $type = undef;
+        }
+        elsif ($flag) {
+          $caption = $1 if /\s+External Connector Type:.*\((.+)\)/i;
+          $description = $1 if /\s+External Reference Designator:\s*(.+)/i;
+          $type = $1 if /\s+Port Type:.*\((.+)\)/i;
+        }
+
+      }
+    }
+    elsif( $aarch eq "sparc" ) {
+      #
+      # For a Sparc arch, we're done
+      #
+    }
+
+  }
+}
+
+1;
+

--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/Slots.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/Slots.pm
@@ -21,103 +21,348 @@ sub run {
     my $model;
     my $sun_class;
 
-    $model=`uname -i`;
+    chomp($model = `uname -i`);
     # debug print model
     #print "Model: '$model'";
-    # cut the CR from string model
-    $model = substr($model, 0, length($model)-1);
+    $sun_class = 0;
     # we map (hopfully) our server model to a known class
-    if ($model eq "SUNW,SPARC-Enterprise") { $sun_class = 1; }
-    if ($model eq "SUNW,SPARC-Enterprise-T5120") { 
-        $sun_class = 2 ; 
-    } else { 
-        $sun_class = 0; 
-    }
+    if ($model =~ /SUNW,SPARC-Enterprise/) { $sun_class = 1; }	# M9000
+    if ($model =~ /SUNW,SPARC-Enterprise-T\d/) { $sun_class = 22; }	# T5220
+    if ($model =~ /SUNW,Sun-Fire-\d/) { $sun_class = 3; }		# 280R, 480R
+    if ($model =~ /SUNW,Sun-Fire-V\d/) { $sun_class = 3; }	# V490
+    if ($model =~ /SUNW,Sun-Fire-T\d/) { $sun_class = 4; }	# T2000
+    if ($model =~ /SUNW,Sun-Blade-1500/) { $sun_class = 8; }	# Blade 1500 workstation
+    if ($model =~ /i86pc/)	{ $sun_class = 21; }		# x86 hardware
+    if ($model =~ /SUNW,T5/)	{ $sun_class = 22; }		# T5240, T5440
+    if ($model =~ /sun4v/)	{ $sun_class = 22; }		# T3-x, T4-x, T5-x
     #Debug
     #print "sun_class : $sun_class\n";
 
+    if ( $sun_class == 0 ) {
+       # Default class, probably doesn't work
 
       foreach (`prtdiag `) {
-      #print $_."\n";
-   
-     if ( $sun_class == 0 )
-     {
-      last if(/^\=+/ && $flag_pci);
-      next if(/^\s+/ && $flag_pci);
-      if($flag && $flag_pci && /^(\S+)\s+/){
-        $name = $1;
-      }
-      if($flag && $flag_pci && /(\S+)\s*$/){
-        $designation = $1;
-      }
-      if($flag && $flag_pci && /^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)/){
-        $description = $1;
-      }
-      if($flag && $flag_pci && /^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)/){
-        $status = $1;
-      }
-      if($flag && $flag_pci){
-        $common->addSlot({
-            DESCRIPTION =>  $description,
-            DESIGNATION =>  $designation,
-            NAME            =>  $name,
-            STATUS          =>  $status,
-            });
-      }
-      if(/^=+\s+IO Cards/){$flag_pci = 1;}
-      if($flag_pci && /^-+/){$flag = 1;}
+        last if(/^\=+/ && $flag_pci);
+        next if(/^\s+/ && $flag_pci);
 
-     }
-     
-     if ( $sun_class == 1 )
-     {
-	last if(/^\=+/ && $flag_pci && $flag);
-	
-	if($flag && $flag_pci && /^\s+(\d+)/){
-             $name = "LSB " . $1;	 
+        if($flag && $flag_pci && /^(\S+)\s+/) {
+          $name = $1;
+        }
+        if($flag && $flag_pci && /(\S+)\s*$/) {
+	  $designation = $1;
 	}
-   	if($flag && $flag_pci && /^\s+\S+\s+(\S+)/){
-                  $description = $1;
-          }
-          if($flag && $flag_pci && /^\s+\S+\s+\S+\s+(\S+)/){
-                  $designation = $1;
-          }
-	$status = " ";
-	
-	#Debug
-	#if ($flag && $flag_pci){print "$name" . "||||" . "$designation" . "||" . "$description\n";}
-      	#print $_."\n";
+	if($flag && $flag_pci && /^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)/) {
+	  $description = $1;
+	}
+	if($flag && $flag_pci && /^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)/) {
+          $status = $1;
+	}
+	if($flag && $flag_pci) {
+          $common->addSlot({
+            DESCRIPTION =>  $description,
+	    DESIGNATION =>  $designation,
+	    NAME        =>  $name,
+	    STATUS      =>  $status,
+          });
+	}
+	if(/^=+\s+IO Cards/){$flag_pci = 1;}
+	if($flag_pci && /^-+/){$flag = 1;}
+      }
+    }
 
-          if($flag && $flag_pci){
+   
+    if ( $sun_class == 1 ) {
+      # M9000
+      #========================= IO Devices =========================
+      #
+      #    IO                                                Lane/Frq
+      #LSB Type  LPID   RvID,DvID,VnID       BDF       State Act,  Max   Name                           Model
+      #--- ----- ----   ------------------   --------- ----- ----------- ------------------------------ --------------------
+      #    Logical Path
+      #    ------------
+      #00  PCIx  0       8,  125, 1033       2,  0,  0  okay   133,  133  pci-pciexclass,060400          N/A
+      #    /pci@0,600000/pci@0
+      #
+
+      foreach (`prtdiag -v`) {
+	last if(/^\=+/ && $flag_pci && $flag);
+
+	if ($flag && $flag_pci && /^(\d+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+((\S+)-\S+)\s+(\S+).*/ ) {
+	  $designation = "LSB " . $1;
+	  $status = $3;
+	  $name = $4;
+	  $description = "[$2] $5";
+	  $description .= " ($6)" unless ($6=~/N\/A/);
+
           $common->addSlot({
             DESCRIPTION =>  $description,
             DESIGNATION =>  $designation,
             NAME            =>  $name,
             STATUS          =>  $status,
             });
-          }
-          if(/^=+\S+\s+IO Cards/){$flag_pci = 1;  }
-          if($flag_pci && /^-+/){$flag = 1;}
-     }
-     if ( $sun_class == 2 )
-     {
-	if (/pci/)
-	{
-	@pci = split(/ +/);
-	$name=$pci[4]." ".$pci[5];
-	$description=$pci[0]." (".$pci[1].")";
-	$designation=$pci[3];
-	$status="";
-	$common->addSlot({
+        }
+        if(/^=+\S+\s+IO Devices/){$flag_pci = 1;  }
+        if($flag_pci && /^-+/){$flag = 1;}
+      }
+    }
+
+
+    if ( $sun_class == 2 ) {
+      # to be checked
+      foreach (`prtdiag `) {
+        if (/pci/) {
+	  @pci = split(/ +/);
+	  $name=$pci[4]." ".$pci[5];
+	  $description=$pci[0]." (".$pci[1].")";
+	  $designation=$pci[3];
+	  $status="";
+	  $common->addSlot({
+            DESCRIPTION =>  $description,
+	    DESIGNATION =>  $designation,
+	    NAME        =>  $name,
+	    STATUS      =>  $status,
+	   });
+	}
+      }	
+    }
+
+
+    if ( $sun_class == 3 ) {
+      # SUNW,Sun-Fire-480R
+      # ========================= IO Cards =========================
+      # 
+      #                     Bus  Max
+      #  IO  Port Bus       Freq Bus  Dev,
+      # Type  ID  Side Slot MHz  Freq Func State Name                              Model
+      # ---- ---- ---- ---- ---- ---- ---- ----- --------------------------------  ----------------------
+      # PCI   8    B    3    33   33  3,0  ok    SUNW,qlc-pci1077,2312.1077.101.2+                       
+      # PCI   8    B    3    33   33  3,1  ok    SUNW,qlc-pci1077,2312.1077.101.2+                       
+      # PCI   8    B    5    33   33  5,0  ok    pci-pci1011,25.4/pci108e,1000     PCI-BRIDGE            
+      # PCI   8    B    5    33   33  0,0  ok    pci108e,1000-pci108e,1000.1       device on pci-bridge  
+      # PCI   8    B    5    33   33  0,1  ok    SUNW,qfe-pci108e,1001             SUNW,pci-qfe/pci-bridg+
+
+      foreach (`prtdiag `) {
+	last if(/^\=+/ && $flag_pci && $flag);          # End of IO Devices, next section starts here
+
+        if($flag && $flag_pci && /PCI/) {
+	  @pci = split(/ +/);
+	  $name=join(" ",@pci[9..$#pci]);
+	  $description="[".$pci[0]."] ".$pci[8];
+	  $designation=$pci[0]."/".$pci[1]."/".$pci[2]."/".$pci[3];
+	  $status=$pci[7];
+
+	  $common->addSlot({
+            DESCRIPTION =>  $description,
+            DESIGNATION =>  $designation,
+            NAME        =>  $name,
+            STATUS      =>  $status,
+            });
+        }
+
+        if(/^=+\S+\s+IO Cards/){
+	  $flag_pci = 1;                  # Start of IO Devices section, still header to skip
+        }
+
+        if($flag_pci && /^-+/){
+	  $flag = 1;                      # End of IO Devices header, real info starts here
+        }
+      }
+    }
+
+
+    if ( $sun_class == 21 ) {
+      # x86 hardware
+
+      $flag = 0;
+      foreach (`/usr/sbin/smbios -t SMB_TYPE_SLOT`) {
+        if ($flag && /^ID.*/) {
+          # write current slot
+          $common->addSlot({
+	    DESCRIPTION =>  "$description ($status)",
+	    DESIGNATION =>  $designation,
+	    NAME        =>  $name,
+	    STATUS      =>  $status,
+            });
+	  $flag = 0;
+	}
+	elsif(/\s+Location Tag:\s+(.*)$/) {
+	  $description = $1;
+	}
+	elsif(/\s+Slot ID:\s+(.*)$/) {
+	  $designation= $1;
+	}
+	elsif(/\s+Type:\s+\S+\s+\((.*)\)$/) {
+	  $name= $1;
+	}
+	elsif(/\s+Usage:\s+\S+\s+\((.*)\).*$/) {
+	  $status = $1;
+	}
+	$flag = 1;
+      }
+
+      # Finally add the last card
+      $common->addSlot({
+        DESCRIPTION =>  "$description ($status)",
+	DESIGNATION =>  $designation,
+	NAME        =>  $name,
+	STATUS      =>  $status,
+        });
+    }
+
+
+    if ( $sun_class == 4 ) {
+      # SUNW,Sun-Fire-T200
+      #========================= IO Configuration =========================
+      #
+      #            IO
+      #Location    Type  Slot Path                                          Name                      Model
+      #----------- ----- ---- --------------------------------------------- ------------------------- ---------
+      #IOBD/PCIE0   PCIE    0                /pci@780/pci@0/pci@8/network@0    network-pciex8086,105e SUNW,pcie+
+
+      foreach(`prtdiag `) {
+	last if(/^\=+/ && $flag_pci && $flag);          # End of IO Devices, next section starts here
+
+	if($flag && $flag_pci && /PCI/) {
+          @pci = split(/ +/);
+	  $name=$pci[5];
+	  $description="[".$pci[1]."] ".$pci[4];
+	  $designation=$pci[0];
+	  $status=" ";
+
+	  if($flag && $flag_pci) {
+	    $common->addSlot({
+              DESCRIPTION =>  $description,
+              DESIGNATION =>  $designation,
+              NAME        =>  $name,
+              STATUS      =>  $status,
+              });
+	  }
+	}
+
+	if(/^=+\S+\s+IO Configuration/){
+	  $flag_pci = 1;                  # Start of IO Devices section, still header to skip
+	}
+
+	if($flag_pci && /^-+/){
+	  $flag = 1;                      # End of IO Devices header, real info starts here
+	}
+      }
+    }
+
+
+    if ( $sun_class == 8 ) {
+      # SUNW,Sun-Blade-1500
+      #================================= IO Devices =================================
+      #Bus     Freq  Slot +      Name +
+      #Type    MHz   Status      Path                          Model
+      #------  ----  ----------  ----------------------------  --------------------
+      #pci     33    MB          isa/su (serial)                                  
+      #              okay        /pci@1e,600000/isa@7/serial@0,3f8
+
+      foreach (`prtdiag `) {
+	last if(/^\=+/ && $flag_pci && $flag);		# End of IO Devices, next section starts here
+
+	#                         pci     33      MB      isa/su(serial)   SUNW,xxx
+	if($flag && $flag_pci && /(\S+)\s+(\S+)\s+(\S+)\s+(\S+\s+\(\S+\))\s*(.*)/) {
+	  $name = $5;
+	  $designation = $3;
+	  $description = "[$1] $4";
+	  $status = " ";
+       
+	  $common->addSlot({
             DESCRIPTION =>  $description,
             DESIGNATION =>  $designation,
             NAME            =>  $name,
             STATUS          =>  $status,
             });
-	
 	}
-	
-     }
+
+	if(/^=+\S+\s+IO Devices/){
+	  $flag_pci = 1;			# Start of IO Devices section, still header to skip
+	}
+
+	if($flag_pci && /^-+/){
+	  $flag = 1;			# End of IO Devices header, real info starts here
+	}
+      }
     }
+
+
+    if ( $sun_class == 22 ) {
+      # SUNW,T5440
+      #======================================== IO Devices =======================================
+      #Slot +            Bus   Name +                            Model      Max Speed  Cur Speed 
+      #Status            Type  Path                                         /Width     /Width    
+      #-------------------------------------------------------------------------------------------
+      #MB/HBA            PCIE  scsi-pciex1000,58                 LSI,1068E  --         --	
+      #                        /pci@400/pci@0/pci@1/scsi@0                 
+
+      # SPARC T3-1
+      #================================= IO Devices =================================
+      #Slot +            Bus   Name +                            Model        Speed 
+      #Status            Type  Path                                                 
+      #------------------------------------------------------------------------------
+      #/SYS/MB/SASHBA0   PCIE  scsi-pciex1000,72                 LSI,2008     --
+      #                        /pci@400/pci@1/pci@0/pci@4/scsi@0           
+      #/SYS/MB/RISER2/PCIE2PCIE  network-pciex108e,abcd            SUNW,pcie-qgc  --
+      #                        /pci@400/pci@1/pci@0/pci@6/network@0        
+
+      # SPARC T4-4
+      #======================================== IO Devices =======================================
+      #Slot +            Bus   Name +                            Model      Max Speed  Cur Speed 
+      #Status            Type  Path                                         /Width     /Width    
+      #-------------------------------------------------------------------------------------------
+      #/SYS/MB/REM0/SASHBA0 PCIE  LSI,sas-pciex1000,72              LSI,2008   --         --
+      #                        /pci@400/pci@1/pci@0/pci@0/LSI,sas@0        
+      #/SYS/RIO/NET0     PCIE  network-pciex8086,10c9                       --         --
+      #                        /pci@400/pci@1/pci@0/pci@2/network@0        
+      #/SYS/RIO/NET1     PCIE  network-pciex8086,10c9                       --         --
+      #                        /pci@400/pci@1/pci@0/pci@2/network@0,1      
+      #/SYS/PCI-EM2      PCIE  SUNW,qlc-pciex1077,2532           QEM3572    --         --
+      #                        /pci@400/pci@1/pci@0/pci@4/pci@0/pci@2/SUNW,qlc@0
+
+      # SPARC T5-4
+      #======================================== IO Devices =======================================
+      #Slot +            Bus   Name +                            Model      Max Speed  Cur Speed 
+      #Status            Type  Path                                         /Width     /Width    
+      #-------------------------------------------------------------------------------------------
+      #/SYS/MB/USB_CTLR  PCIE  usb-pciexclass,0c0330                        --         --
+      #                        /pci@300/pci@1/pci@0/pci@4/pci@0/pci@6/usb@0
+      #/SYS/RIO/XGBE0    PCIE  network-pciex8086,1528                       --         --
+      #                        /pci@300/pci@1/pci@0/pci@4/pci@0/pci@8/network@0
+      #/SYS/MB/SASHBA0   PCIE  scsi-pciex1000,87                 LSI,2308_2 --         --
+      #                        /pci@300/pci@1/pci@0/pci@4/pci@0/pci@c/scsi@0
+
+      foreach (`prtdiag `) {
+	last if(/^\=+/ && $flag_pci && $flag);		# End of IO Devices, next section starts here
+
+	# Lazy match for $name due to differences in prtdiag output:
+	#    * the "Model" column does not always have a value	
+	#    * 5-column output on Sol10, 6-column output on Sol11
+	if($flag && $flag_pci && /(\S+)\s+(\S+)\s+((\S+)-\S+)\s+(\S+)\s+.*/) {
+	  $designation = $1;
+	  $status = " ";
+	  $name = $3;
+	  $description = "[$2] $4";
+	  $description .= " ($5)" unless ($5=~/.*GT\/?x\d+|--/);
+
+	  $common->addSlot({
+            DESCRIPTION =>  $description,
+            DESIGNATION =>  $designation,
+            NAME            =>  $name,
+            STATUS          =>  $status,
+            });
+	}
+
+	if(/^=+\S+\s+IO Devices/){
+	  $flag_pci = 1;			# Start of IO Devices section, still header to skip
+	}
+
+	if($flag_pci && /^-+/){
+	  $flag = 1;			# End of IO Devices header, real info starts here
+	}
+      }
+    }
+ 
 }
 1;

--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/Storages.pm
@@ -40,11 +40,6 @@ sub run {
     foreach(`iostat -En`){
         #print;
         if ($flag_first_line){          
-            if (/^.*<(\S+)\s*bytes/){              
-                $capacity = $1;
-                $capacity = $capacity/(1024*1024);
-                #print $capacity."\n";
-            }
             ## To be removed when FIRMWARE will be supported
             if ($rev) {
                 $description .= ' ' if $description;
@@ -57,6 +52,8 @@ sub run {
                 $type="FC";
             } elsif( $rdisk_path =~ /.*->.*scsi@.*/ ) {
                 $type="SCSI";
+            } elsif( $rdisk_path =~ /.*->.*virtual-devices.*/ ) {
+                $type="Virtual";
             }
             $common->addStorages({
                 NAME => $name,
@@ -82,6 +79,11 @@ sub run {
         }
         if (/^.*Product:\s*(\S+)/){
             $model = $1;
+        }
+        if (/^.*<(\S+)\s*bytes/){              
+            $capacity = $1;
+            $capacity = $capacity/(1024*1024);
+            #print $capacity."\n";
         }
         if (/^.*Serial No:\s*(\S+)/){
            $sn = $1;

--- a/lib/Ocsinventory/Agent/Backend/Virtualization/SolarisLdoms.pm
+++ b/lib/Ocsinventory/Agent/Backend/Virtualization/SolarisLdoms.pm
@@ -1,0 +1,64 @@
+package Ocsinventory::Agent::Backend::Virtualization::SolarisLdoms;
+
+use strict;
+
+sub check {
+    my $params = shift;
+    my $common = $params->{common};
+    return unless $common->can_run('ldm');
+}
+
+sub run {
+  my @ldoms;
+  my $ldom;
+  my @ldomdetails;
+  my $ldomdetail;
+  my $ldomname;
+  my $ldomstatus;
+  my $ldommem;
+  my $ldomncpu;
+  my $ldomuuid;
+  my $ldomsoftstate;
+  my $params = shift;
+  my $common = $params->{common};
+  my $logger = $params->{logger};
+
+  @ldoms = `/usr/sbin/ldm list-domain -p`;
+
+  foreach $ldom (@ldoms) {
+    if($ldom =~ /^DOMAIN\|name=(\S+)\|state=(\S+)\|flags=\S+\|cons=\S+\|ncpu=(\d+)\|mem=(\d+)\|.*/) {
+        $ldomname=$1;
+        $ldomstatus=$2;
+        $ldomncpu=$3;
+        $ldommem=$4/1024/1024;
+        $ldomsoftstate="";
+
+        @ldomdetails = `/usr/sbin/ldm list-domain -o domain -p $ldomname`;
+
+        foreach $ldomdetail (@ldomdetails) {
+          if($ldomdetail =~ /^DOMAIN\|.*\|softstate=(.*)$/) {
+            $ldomsoftstate=$1;
+          } elsif($ldomdetail =~ /^UUID\|uuid=(.*)$/) {
+            $ldomuuid=$1;
+          }
+        }
+
+        my $machine = {
+
+            MEMORY => $ldommem,
+            NAME => $ldomname,
+            UUID => $ldomuuid,
+            STATUS => $ldomstatus,
+            SUBSYSTEM => $ldomsoftstate,
+            VMTYPE => "Solaris Ldom",
+            VCPU => $ldomncpu,
+
+        };
+
+        $common->addVirtualMachine($machine);
+
+    }
+  }
+}
+
+1;

--- a/memconf
+++ b/memconf
@@ -6,7 +6,7 @@
 #
 # @(#) memconf - Identify sizes of memory modules installed on a
 # @(#)           Solaris, Linux, FreeBSD or HP-UX workstation or server.
-# @(#) Micron Technology, Inc. - Tom Schmidt 08-Sep-2016 V3.11
+# @(#) Micron Technology, Inc. - Tom Schmidt 28-Feb-2017 V3.13
 #
 # Maintained by Tom Schmidt (tschmidt@micron.com)
 #
@@ -79,7 +79,7 @@
 #   - sun4v Sun SPARC Enterprise T2000, T1000 Server
 #   - sun4v Sun SPARC Enterprise T5120, T5140, T5220, T5240 Server, Netra T5220
 #   - sun4v Sun SPARC Enterprise T5440 Server, Netra T5440
-#   - sun4v Oracle SPARC T3-1, T3-1B, T3-2, T4-1, T4-2, T4-4, T5-2, T5-4
+#   - sun4v Oracle SPARC T3-1, T3-1B, T3-2, T4-1, T4-2, T4-4, T5-2, T5-4, S7-2
 #   - sun4v Fujitsu SPARC M10-1, M10-4
 #   - sun4m Tatung COMPstation 5, 10, 20AL, 20S and 20SL clones
 #   - sun4m transtec SPARCstation 20I clone
@@ -109,8 +109,9 @@
 # - sun4u Sun Netra ct400, ct410, ct810
 # - sun4u Sun SPARCengine CP2040, CP2060, CP2080, CP2160
 # - sun4v Sun Netra CP3260
-# - sun4v Oracle SPARC T3-1BA, T3-4, T4-1B, T4-2B, T5-8, T5-1B
-# - sun4v Oracle SPARC M5-32, M6-32
+# - sun4v Oracle SPARC S7-2L
+# - sun4v Oracle SPARC T3-1BA, T3-4, T4-1B, T4-2B, T5-8, T5-1B, T7-1, T7-2, T7-4
+# - sun4v Oracle SPARC M5-32, M6-32, M7-8, M7-16
 # - sun4v Oracle Netra SPARC T3 systems
 # - sun4v Fujitsu SPARC M10-4S
 # - May not work properly on Sun clones
@@ -131,8 +132,8 @@
 $^W=1;	# Enables -w warning switch, put here for SunOS4 compatibility.
 $starttime=(times)[0];
 
-$version="V3.11";
-$version_date="08-Sep-2016";
+$version="V3.13";
+$version_date="28-Feb-2017";
 $URL="http://sourceforge.net/projects/memconf/";
 
 $newpath="/usr/sbin:/sbin:/bin:/usr/bin:/usr/ucb:/usr/local/bin:/var/local/bin";
@@ -252,14 +253,14 @@ if (-d '/usr/platform') {
 		$prtdiag_cmd="/usr/platform/$platform/sbin/prtdiag";
 	} elsif (-x "/usr/platform/$machine/sbin/prtdiag") {
 		$prtdiag_cmd="/usr/platform/$machine/sbin/prtdiag";
-	} elsif (-x "/usr/sbin/prtdiag") {
+	} elsif (-x '/usr/sbin/prtdiag') {
 		$prtdiag_cmd="/usr/sbin/prtdiag";
 	}
 } elsif (-x '/usr/kvm/prtdiag') {
 	$platform=$machine;
 	$prtdiag_cmd='/usr/kvm/prtdiag';
-} elsif (-x "/usr/sbin/prtdiag") {
-	$platform=$machine;
+} elsif (-x '/usr/sbin/prtdiag') {
+	$platform=&mychomp(`$uname -i`);
 	$prtdiag_cmd="/usr/sbin/prtdiag";
 }
 if ($prtdiag_cmd) {
@@ -441,9 +442,13 @@ $picl_foundmemory=0;
 @picl_mem_pn=();
 @picl_mem_bank=();
 @picl_mem_dimm=();
-$uid=&mychomp(`id`);
-$uid=~s/uid=//;
-$uid=~s/\(.*//;
+if (-x '/usr/bin/id') {
+	$uid=&mychomp(`/usr/bin/id`);
+	$uid=~s/uid=//;
+	$uid=~s/\(.*//;
+} else {
+	$uid=0; # assume super-user
+}
 $empty_memory_printed=0;
 @filelist=();
 
@@ -642,6 +647,19 @@ if (! $filename) {
 		}
 	} elsif ($os =~ /Linux|FreeBSD/) {
 		&linux_distro if (! $release);
+		if ($machine =~ /arm/i) {
+			if (-f '/etc/Alt-F' && -f '/tmp/board') {
+				# NAS model
+				open(FILE, "</tmp/board");
+				$model=&mychomp(<FILE>);
+				close(FILE);
+			} elsif (-f '/etc/model') {
+				# DLink NAS model
+				open(FILE, "</etc/model");
+				$model=&mychomp(<FILE>);
+				close(FILE);
+			}
+		}
 		# Use dmidecode for Linux x86, not for Linux SPARC
 		&check_dmidecode if ($config_cmd =~ /dmidecode/ && -x "$config_cmd" && ($machine =~ /.86/ || ! -x '/usr/sbin/prtconf'));
 		if ($machine =~ /.86/ || ! -e '/dev/openprom') {
@@ -1135,10 +1153,19 @@ sub show_header {
 				print ", ${kernbit}-bit kernel, " if ($kernbit);
 			}
 			if ($os =~ /Linux|FreeBSD/ && $release) {
-				if (-x "/bin/busybox") {
-					$bbversion=`/bin/busybox 2>/dev/null | awk '/^BusyBox / {print \$2}'`;
-					$bbversion=&mychomp($bbversion);
-					print "BusyBox $bbversion, ";
+				if (-x '/bin/busybox') {
+					@busybox=`/bin/busybox cat --help 2>&1`;
+					$busyboxver="";
+					for (@busybox) {
+						next if (! /^BusyBox/);
+						$busyboxver=&mychomp($_);
+						$busyboxver=~s/\).*$/\)/;
+					}
+					if ($busyboxver) {
+						print "$busyboxver, ";
+					} else {
+						print "BusyBox, ";
+					}
 				}
 				print "$release\n";
 			} else {
@@ -1292,10 +1319,10 @@ sub show_header {
 		if ($format_cpu == 1) {
 			print "CPU Units: Frequency Cache-Size Version\n" if ($model =~ /-Enterprise/ || $ultra eq "e");
 		} else {
-			print "CPU Units:\n" if (! $ldm_memory);
+			print "CPU Units:\n";
 		}
 		if ($model ne "SPARCserver-1000" && $model ne "SPARCcenter-2000") {
-			print @boards_cpu if (! $ldm_memory);
+			print @boards_cpu;
 			print "Memory Units:\n" if (! &is_virtualmachine);
 		}
 	}
@@ -1567,6 +1594,14 @@ sub check_model {
 	$ultra="M10-1" if ($model =~ /SPARC-M10-1\b/ || $modelbanner =~ /SPARC M10-1\b/);
 	$ultra="M10-4" if ($model =~ /SPARC-M10-4\b/ || $modelbanner =~ /SPARC M10-4\b/);
 	$ultra="M10-4S" if ($model =~ /SPARC-M10-4S\b/ || $modelbanner =~ /SPARC M10-4S\b/);
+	# SPARC S7 and M7 systems
+	$ultra="S7-2" if ($model =~ /SPARC-S7-2\b/ || $modelbanner =~ /SPARC S7-2\b/);
+	$ultra="S7-2L" if ($model =~ /SPARC-S7-2L\b/ || $modelbanner =~ /SPARC S7-2L\b/);
+	$ultra="T7-1" if ($model =~ /SPARC-T7-1\b/ || $modelbanner =~ /SPARC T7-1\b/);
+	$ultra="T7-2" if ($model =~ /SPARC-T7-2\b/ || $modelbanner =~ /SPARC T7-2\b/);
+	$ultra="T7-4" if ($model =~ /SPARC-T7-4\b/ || $modelbanner =~ /SPARC T7-4\b/);
+	$ultra="M7-8" if ($model =~ /SPARC-M7-8\b/ || $modelbanner =~ /SPARC M7-8\b/);
+	$ultra="M7-16" if ($model =~ /SPARC-M7-16\b/ || $modelbanner =~ /SPARC M7-16\b/);
 
 	# Older SPARCstations
 	$modelmore="SPARCstation SLC" if ($model eq "Sun 4/20");
@@ -1840,8 +1875,11 @@ sub add_to_sockets_used {
 	$_=shift;
 	# strip leading slash for matching
 	$_=~s/^\///;
-	$sockets_used .= "," if ($sockets_used && /\s/);
-	$sockets_used .= " $_" if ($sockets_used !~ /$_/);
+	if ($sockets_used !~ /$_/) {
+		$sockets_used .= "," if ($sockets_used && /\s/);
+		$sockets_used .= " $_";
+#		&pdebug("in add_to_sockets_used, added $_");
+	}
 }
 
 sub add_to_sockets_empty {
@@ -2082,6 +2120,10 @@ sub check_prtdiag {
 			}
 			if ($linearr[$#linearr] =~ /BB\d+\/CMU[LU]\/CMP[01]\/MEM[01][0-7][AB]/) {
 				# Fujitsu SPARC M10-4, M10-4S (guess)
+				$sockets_used .= " $linearr[$#linearr]";
+			}
+			if ($linearr[$#linearr] =~ /SYS\/MB\/CMP\d+\/MCU\d+\/CH\d+\/D\d+/) {
+				# SPARC S7-2, S7-2L
 				$sockets_used .= " $linearr[$#linearr]";
 			}
 		}
@@ -2585,6 +2627,7 @@ sub check_prtpicl {
 		}
 		if ($line =~ /\s+:name\s+memory-module/) {
 			$flag_mem_mod=0;	# End of memory module section
+			&add_to_sockets_used($mem_dimm);
 		}
 		if (($line =~ /^\s+\w.*/ && $line !~ /^\s+memory-/ && $has_picl_mem_mod) || ($line =~ /\s+:name\s/ && ! $has_picl_mem_mod)) {
 			$flag_mem_seg=0;
@@ -2604,9 +2647,9 @@ sub check_prtpicl {
 				}
 				$flag_mem_mod=0;	# End of memory module section
 				&add_to_sockets_used($socket);
-				if (defined($mem_model)) {
+				if (defined($mem_model) && defined($mem_mfg)) {
 					$picl_mem_pn{"$socket"}="$mem_mfg $mem_model";
-				} else {
+				} elsif (defined($mem_mfg)) {
 					$picl_mem_pn{"$socket"}="$mem_mfg";
 				}
 				if ($max_picl_dimm_per_bank) {
@@ -2942,8 +2985,10 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 4 / $ncpu . "-Core Quad-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 4 / $ncpu . "-Core Quad-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /UltraSPARC-T2\+/) {
 		$cputype="UltraSPARC-T2+";
 		# Count 8-Thread (4, 6, or 8 Core) Victoria Falls CPUs as 1 CPU
@@ -2969,8 +3014,10 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /UltraSPARC-T2$/) {
 		$cputype="UltraSPARC-T2";
 		# Count 8-Thread (4 or 8 Core) Niagara-II CPUs as 1 CPU
@@ -2984,8 +3031,10 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /SPARC-T3$/) {
 		$cputype="SPARC-T3";
 		# Count 8-Thread (8 or 16 Core) Rainbow Falls CPUs as 1 CPU
@@ -2999,8 +3048,10 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /SPARC-T4$/) {
 		$cputype="SPARC-T4";
 		# Count 8-Thread 8-Core SPARC-T4 CPUs as 1 CPU
@@ -3014,8 +3065,10 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /SPARC-T5$/) {
 		$cputype="SPARC-T5";
 		# Count 8-Thread 16-Core SPARC-T5 CPUs as 1 CPU
@@ -3029,8 +3082,10 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /SPARC.M5$/) {
 		$cputype="SPARC-M5";
 		# Count 8-Thread 6-Core SPARC-M5 CPUs as 1 CPU
@@ -3044,8 +3099,10 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /SPARC.M6$/) {
 		$cputype="SPARC-M6";
 		# Count 8-Thread 12-Core SPARC-M6 CPUs as 1 CPU
@@ -3059,8 +3116,44 @@ sub multicore_cpu_cnt {
 			$cnt=$ncpu;
 			return;
 		}
-		$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
-		$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
+	} elsif ($cputype =~ /SPARC.S7$/) {
+		$cputype="SPARC-S7";
+		# Count 8-Thread 8-Core SPARC-S7 CPUs as 1 CPU
+		if ($npcpu && $ldm_cmd && ! $have_ldm_data) {
+			$ncpu=$npcpu;
+		} else {
+			# Each CPU has 8 Cores max (64 threads)
+			$ncpu=int(($threadcnt - 1) / 64) + 1;
+		}
+		if (defined($arg)) {
+			$cnt=$ncpu;
+			return;
+		}
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
+	} elsif ($cputype =~ /SPARC.M7$/) {
+		$cputype="SPARC-M7";
+		# Count 8-Thread 32-Core SPARC-M7 CPUs as 1 CPU
+		if ($npcpu && $ldm_cmd && ! $have_ldm_data) {
+			$ncpu=$npcpu;
+		} else {
+			# Each CPU has 32 Cores max (256 threads)
+			$ncpu=int(($threadcnt - 1) / 256) + 1;
+		}
+		if (defined($arg)) {
+			$cnt=$ncpu;
+			return;
+		}
+		if ($threadcnt) {
+			$cputype=$threadcnt / 8 / $ncpu . "-Core 8-Thread $cputype";
+			$cpucnt{"$cputype $cpufreq"}=$ncpu;
+		}
 	} elsif ($cputype =~ /SPARC64-VI$/) {
 		# Count Dual-Core Dual-Thread Olympus-C SPARC64-VI CPUs as 1 CPU
 		$ncpu=$threadcnt / 4;
@@ -3245,11 +3338,11 @@ sub get_mfg {
 	&pdebug("in get_mfg, JEDEC_ID=$_");
 	return "" if (/(^$|^\r$|^FFFFFFFFFFFF|^000000000000|^Undefined|Manufacturer\d)/i);
 	s/^(00|80)// if (! /^007F/);
-	# Based on JEDEC JEP106AB
+	# Based on JEDEC JEP106AT
 	return "Micron Technology" if (/(^2C|Micron\b)/i);
 	return "Micron CMS" if (/(^7F45|Micron CMS)/i);
 	return "Crucial Technology" if (/(^1315$|^859B|^9B|^7F7F7F7F7F9B|Crucial\b)/i);
-	# Inotera is a Joint Venture between Micron and Nanya
+	# Inotera was a Joint Venture between Micron and Nanya
 	# Micron fully acquired Inotera in 2016
 	return "Inotera Memories" if (/Inotera/i);
 	# Micron acquired Elpida in August 2013
@@ -3294,11 +3387,12 @@ sub get_mfg {
 	return "Kingston" if (/(^7F98|^0198|Kingston)/i);
 	return "SpecTek Incorporated" if (/(^7F7FB5|SpecTek)/i);
 	return "Nanya Technology" if (/(^7F7F7F0B|^830B|Nanya)/i);
+	return "Kingmax Semiconductor" if (/(^7F7F7F25|KINGMAX)/i);
 	return "Ramaxel Technology" if (/(^7F7F7F7F43|Ramaxel)/i);
-	return "ADATA Technology" if (/(^7F7F7F7FCB|ADATA|A-DATA)/i);
+	return "A-DATA Technology" if (/(^7F7F7F7FCB|ADATA|A-DATA)/i);
+	return "Team Group Inc." if (/^(7F7F7F7FEF|Team\b)/i);
 	return "AMD" if (/^01/);
 	return "AMI" if (/^02/);
-	return "KINGMAX" if (/(^7F7F7F25|KINGMAX)/i);
 	if ($has_JEDEC_ID || /^7F|^80|^FF/i) {
 		$unknown_JEDEC_ID=1;
 		&pdebug("in get_mfg, found unknown JEDEC ID $_");
@@ -3313,6 +3407,7 @@ sub check_ipmitool {
 	$cputype2="";
 	$mem_mfg="";
 	$mem_model="";
+	$mem_pn="";
 	$flag_cpu=0;
 	$flag_mem=0;
 	$flag_mfg=0;
@@ -3338,7 +3433,7 @@ sub check_ipmitool {
 				}
 			}
 			if ($flag_mem && $socket) {
-				$ipmi_mem{"$socket"}=("$mem_mfg$mem_model") ? "$mem_mfg $mem_model" : "";
+				$ipmi_mem{"$socket"}=("$mem_mfg$mem_model$mem_pn") ? "$mem_mfg $mem_model$mem_pn" : "";
 			}
 			$flag_cpu=0;	# End of CPU section
 			$flag_mem=0;	# End of memory section
@@ -3346,13 +3441,14 @@ sub check_ipmitool {
 			$cputype2="";
 			$mem_mfg="";
 			$mem_model="";
+			$mem_pn="";
 		}
 		if ($line =~ / (cpu\d+\.vpd|p\d+\.fru )/) {
 			$flag_cpu=1;	# Start of CPU section
 			$socket=$line;
 			$socket=~s/^.*: +(.*\S)\.[vf][pr][du].*$/$1/;
 		}
-		if ($flag_cpu && ($line =~ / Product Name /)) {
+		if ($flag_cpu && $line =~ / Product Name /) {
 			$cputype2=$line;
 			$cputype2=~s/^.*: +(.*\S) *$/$1/;
 			&x86multicorecnt($cputype2);
@@ -3361,22 +3457,37 @@ sub check_ipmitool {
 			$flag_mem=1;	# Start of memory module section
 			$socket=$line;
 			$socket=~s/^.*: +(.*\S)\.[vf][pr][du].*$/$1/;
+		} elsif ($line =~ / P\d+C\d+\/B\d+\/C\d+\/D\d+ / && $ultra =~ /^T7-/) {
+			# Need what M7-8 and M7-16 format looks like
+			$flag_mem=1;	# Start of memory module section
+			$socket=$line;
+			$socket=~s/^.*: +(.*\S)\s*.*$/$1/;
 		}
-		if ($flag_mem && ($line =~ / Product Manufacturer /)) {
+		if ($flag_mem && $line =~ / Device not present /) {
+			# Ignore missing Processor Modules
+			$flag_mem=0 if ($ultra eq "T7-4" && $corecnt == 2 && $socket =~ /P1C\d+\/B\d+\/C\d+\/D\d+/);
+			# Need what M7-8 and M7-16 format looks like
+		}
+		if ($flag_mem && $line =~ / Product Manufacturer /) {
 			$mem_mfg=$line;
 			$mem_mfg=~s/^.*: +(.*\S) *$/$1/;
 			$mem_mfg=&get_mfg($mem_mfg);
 		}
-		if ($flag_mem && ($line =~ / Product Name /)) {
+		if ($flag_mem && $line =~ / Product Name /) {
 			$mem_model=$line;
 			$mem_model=~s/^.*: +(.*\S) *$/$1/;
 			$mem_model=~s/ ADDRESS\/COMMAND//;
 			$mem_model=~s/PARITY/Parity/;
 		}
+		if ($flag_mem && $line =~ / Product Part Number /) {
+			$mem_pn=$line;
+			$mem_pn=~s/^.*: +(.*\S) *$/, $1/;
+			$mem_pn=~s/^, .*,(.*\S)$/, $1/;
+		}
 		if ($line =~ /FRU Device Description *: *\/*SYS /) {
 			$flag_mfg=1;	# Start of mfg section
 		}
-		if ($flag_mfg && ($line =~ / Product Manufacturer /)) {
+		if ($flag_mfg && $line =~ / Product Manufacturer /) {
 			$manufacturer="Sun Microsystems, Inc." if ($line =~ /Sun /i);
 			$manufacturer="Oracle Corporation" if ($line =~ /Oracle/i);
 		}
@@ -3513,6 +3624,18 @@ sub found_guest_LDOM {
 	} elsif ($cputype =~ /SPARC-T5$/) {
 		delete $cpucnt{"$cputype $cpufreq"};
 		$cputype="SPARC-T5";
+		$cpucnt{"$cputype $cpufreq"}=1;
+	} elsif ($cputype =~ /SPARC-M5$/) {
+		delete $cpucnt{"$cputype $cpufreq"};
+		$cputype="SPARC-M5";
+		$cpucnt{"$cputype $cpufreq"}=1;
+	} elsif ($cputype =~ /SPARC-M6$/) {
+		delete $cpucnt{"$cputype $cpufreq"};
+		$cputype="SPARC-M6";
+		$cpucnt{"$cputype $cpufreq"}=1;
+	} elsif ($cputype =~ /SPARC-S7$/) {
+		delete $cpucnt{"$cputype $cpufreq"};
+		$cputype="SPARC-S7";
 		$cpucnt{"$cputype $cpufreq"}=1;
 	}
 	&show_header;
@@ -4083,7 +4206,7 @@ foreach $line (@config) {
 	if (($line =~ /SUNW,(Ultra-|SPARC|S240|JavaEngine1|Ultra.*[Ee]ngine)/ ||
 	    $line =~ /SUNW,(Ultra.*Netra*|Premier-24|UltraAX-|Netra|Grover)/ ||
 	    $line =~ /SUNW,(Enchilada|Serverblade1|Enterprise|A[0-9]|T[0-9])/ ||
-	    $line =~ /ORCL,SPARC-T|Sun.4|SUNW,Axil-|^i86pc|^i86xpv|^i86xen/ ||
+	    $line =~ /ORCL,SPARC-|Sun.4|SUNW,Axil-|^i86pc|^i86xpv|^i86xen/ ||
 	    $line =~ /model:\s+'(SPARC CPU|SPARC CPCI)-/ ||
 	    $line =~ /\s+name:.*(SUNW,Sun-|'i86pc'|COMPstation|Tadpole)/ ||
 	    $line =~ /\s+name:.*(Auspex|S-4|FJSV,GP|CompuAdd|RDI,)/) &&
@@ -4247,7 +4370,7 @@ foreach $line (@config) {
 			$installed_memory=0;
 		}
 		# Round up some odd-number total memory values
-		$installed_memory++ if (sprintf("%3d", ($installed_memory + 1) / 2 ) * 2 != $installed_memory && $installed_memory >= 1023);
+		$installed_memory++ if (sprintf("%3d", ($installed_memory + 1) / 2) * 2 != $installed_memory && $installed_memory >= 1023);
 		$BSD=0;	# prtconf and prtdiag only have this output
 		$config_cmd="/usr/sbin/prtconf -vp" if ($config_cmd !~ /prtconf/);
 		$config_command="prtconf";
@@ -4427,13 +4550,13 @@ foreach $line (@config) {
 &check_cpuinfo;
 &check_xm_info;
 if (! $osrel) {
-	if ($os =~ /Linux|FreeBSD/) {
-		$osrel="2.X";
-	} elsif ($BSD) {
+	if ($BSD) {
 		$osrel="4.X";
 		$config_cmd="/usr/etc/devinfo -pv";
 		$config_command="devinfo";
 		$cpucntfrom="devinfo";
+#	} elsif ($os =~ /Linux|FreeBSD/) {
+#		$osrel="2.X";	# Could also be 3.X Linux kernel, so leave empty
 	} else {
 		$osrel="5.X";
 		$solaris="2.X";
@@ -6855,6 +6978,154 @@ if ($ultra eq "M10-4" || $ultra eq "M10-4S") {
 	}
 	&check_for_LDOM;
 }
+if ($ultra eq "S7-2" || $ultra eq "S7-2L") {
+	# SPARC S7-2 has 1 or 2 SPARC S7 processors at 4.267GHz
+	# SPARC S7-2L has 2 SPARC S7 processors at 4.267GHz
+	# Each SPARC S7 processor supports:
+	#  8 cores, 8 threads.
+	#  16 DIMM slots for up to 1TB memory (16 x 64GB).
+	#  supports 16GB, 32GB & 64GB DDR4 DIMMs.
+	#  Do not mix DIMMs sizes.
+	#  Can be half populated (D0 white sockets), 4 DIMMs per CPU, or
+	#   fully populated (D0 white & D1 black sockets), 8 DIMMs per CPU.
+	$memtype="DDR4 DIMM";
+	$showrange=0;
+	@simmsizes=(16384,32768,65536);
+	$untested=1;
+	$untested=0 if ($ultra eq "S7-2");
+	# /SYS/MB/CMP0/MCU0/CH0/D0 - /SYS/MB/CMP1/MCU1/CH1/D1
+	for $s_d (0,1) {
+		for $s_cmp (0..$corecnt-1) {
+			for $s_mcu (0,1) {
+				for $s_ch (0,1) {
+					push(@socketstr, "/SYS/MB/CMP$s_cmp/MCU$s_mcu/CH$s_ch/D$s_d");
+				}
+			}
+		}
+	}
+	&check_for_LDOM;
+}
+if ($ultra eq "T7-1") {
+	# SPARC T7-1 has 1 SPARC M7 processors at 4.13GHz
+	# SPARC M7 processor supports:
+	#  32 cores, 8 threads
+	#  16 DIMM slots for up to 1TB memory (16 x 64GB)
+	# SPARC T7-1 supports:
+	#  16GB, 32GB & 64GB DDR4 DIMMs
+	#  Left Memory Riser:  /SYS/MB/CM/CMP/MR1/BOB[01]0/CH[01]
+	#  Left Motherboard:   /SYS/MB/CM/CMP/BOB[13]1/CH[01]
+	#  Right Motherboard:  /SYS/MB/CM/CMP/BOB[02]1/CH[01]
+	#  Right Memory Riser: /SYS/MB/CM/CMP/MR0/BOB[23]0/CH[01]
+	#  CH0 Black sockets, CH1 White sockets
+	#  In base configuration, all DIMM slots on motherboard must be
+	#   fully occupied (8 DIMMs).
+	#  In upgrade configuration (16 DIMMs), both memory risers are
+	#   added and must be fully occupied.
+	$memtype="DDR4 DIMM";
+	$showrange=0;
+	@simmsizes=(16384,32768,65536);
+	$untested=1;
+	for $s_bob (0..3) {	# Motherboard
+		for $s_ch (0,1) {
+			push(@socketstr, "/SYS/MB/CM/CMP/BOB${s_bob}1/CH$s_ch");
+		}
+	}
+	for $s_bob (0,1) {	# MR1
+		for $s_ch (0,1) {
+			push(@socketstr, "/SYS/MB/CM/CMP/MR1/BOB${s_bob}0/CH$s_ch");
+		}
+	}
+	for $s_bob (2,3) {	# MR0
+		for $s_ch (0,1) {
+			push(@socketstr, "/SYS/MB/CM/CMP/MR0/BOB${s_bob}0/CH$s_ch");
+		}
+	}
+	&check_for_LDOM;
+}
+if ($ultra eq "T7-2") {
+	# SPARC T7-2 has 2 SPARC M7 processors at 4.13GHz
+	# SPARC M7 processor supports:
+	#  32 cores, 8 threads
+	#  16 DIMM slots for up to 1TB memory (16 x 64GB)
+	# SPARC T7-2 supports:
+	#  16GB, 32GB & 64GB DDR4 DIMMs
+	#  /SYS/MB/CM[01]/CMP/MR[0-3]/BOB[01]/CH[01]/DIMM
+	#    CH0 Black sockets, CH1 White sockets
+	#    All 8 memory risers must be installed in all configurations
+	#    Half-populated configurations populate CH0 Black sockets (16 DIMMs)
+	#    Full-populated configurations fill CH0 and CH1 sockets (32 DIMMs)
+	$memtype="DDR4 DIMM";
+	$showrange=0;
+	@simmsizes=(16384,32768,65536);
+	$untested=1;
+	for $s_ch (0,1) {
+		for $s_cm (0,1) {
+			for $s_mr (0..3) {
+				for $s_bob (0,1) {
+					push(@socketstr, "/SYS/MB/CM$s_cm/CMP/MR$s_mr/BOB$s_bob/CH$s_ch/DIMM");
+				}
+			}
+		}
+	}
+	&check_for_LDOM;
+}
+if ($ultra eq "T7-4") {
+	# SPARC T7-4 has 2 or 4 SPARC M7 processors at 4.13GHz
+	# SPARC M7 processor supports:
+	#  32 cores, 8 threads
+	#  16 DIMM slots for up to 1TB memory (16 x 64GB)
+	# SPARC T7-4 supports:
+	#  16GB, 32GB & 64GB DDR4 DIMMs
+	#  /SYS/PM[0-3]/CM[01]/CMP/BOB[0-3][01]/CH[01]/DIMM
+	#    CH0 Black sockets, CH1 White sockets
+	#    Half-populated configurations populate CH0 Black sockets (16 DIMMs)
+	#    Full-populated configurations fill CH0 and CH1 sockets (32 DIMMs)
+	$memtype="DDR4 DIMM";
+	$showrange=0;
+	@simmsizes=(16384,32768,65536);
+	$untested=1;
+	$untested=0 if ($corecnt == 2);	# 2 SPARC M7 processors tested
+	for $s_pm (0..$npcpu-1) {
+		for $s_ch (0,1) {
+			for $s_cm (0,1) {
+				for $s_boba (0..3) {
+					for $s_bobb (0,1) {
+						push(@socketstr, "/SYS/PM$s_pm/CM$s_cm/CMP/BOB$s_boba$s_bobb/CH$s_ch/DIMM");
+					}
+				}
+			}
+		}
+	}
+	&check_for_LDOM;
+}
+if ($ultra eq "M7-8" || $ultra eq "M7-16") {
+	# SPARC M7-8 has 2 to 8 SPARC M7 processors at 4.13GHz
+	# SPARC M7-16 has 4 to 16 SPARC M7 processors at 4.13GHz
+	# Each SPARC M7 processor has 32 cores, 8 threads
+	# SPARC M7-8 & M7-16 supports:
+	#  16 DIMM slots for up to 512GB memory (16 x 32GB)
+	#  supports 16GB & 32GB DDR4 DIMMs
+	#  SPARC M7-8, has CMIOU_0 to CMIOU_7
+	#  SPARC M7-16, has CMIOU_0 to CMIOU_15
+	#  /SYS/CMIOU[0-15]/CM/CMP/BOB[0-3][01]/CH[01]/DIMM
+	#    CH0 Black sockets, CH1 White sockets
+	#    Half-populated configurations populate CH0 Black sockets (8 DIMMs)
+	#    Full-populated configurations fill CH0 and CH1 sockets (16 DIMMs)
+	$memtype="DDR4 DIMM";
+	$showrange=0;
+	@simmsizes=(16384,32768);
+	$untested=1;
+	for $s_cmiou (0..$npcpu-1) {
+		for $s_ch (0,1) {
+			for $s_boba (0..3) {
+				for $s_bobb (0,1) {
+					push(@socketstr, "/SYS/CM$s_cmiou/CM/CMP/BOB$s_boba$s_bobb/CH$s_ch/DIMM");
+				}
+			}
+		}
+	}
+	&check_for_LDOM;
+}
 if ($model eq "SPARC-Enterprise" || $ultra =~ /SPARC Enterprise M[34589]000 Server/) {
 	# CPUs:  Dual-Core Dual-Thread SPARC64-VI or
 	#        Quad-Core Dual-Thread SPARC64-VII, VII+, VII++
@@ -8435,7 +8706,7 @@ sub hpux_finish {
 			}
 			&show_total_memory;
 			# Check if on a virtual machine (HPVM guest)
-			if (-x "/opt/hpvm/bin/hpvminfo") {
+			if (-x '/opt/hpvm/bin/hpvminfo') {
 				&pdebug("Checking hpvminfo");
 				$tmp=`/opt/hpvm/bin/hpvminfo 2>&1`;
 				if ($tmp =~ /HPVM guest/i) {
@@ -8795,10 +9066,10 @@ sub x86_devname {
 		$familypn="X6270";
 		$untested=0;
 	}
-	if ($m =~ /Sun .*X6275 M2\b/i ) {
+	if ($m =~ /Sun .*X6275 M2\b/i) {
 		# X6275 M2 has 2 Quad-Core or Six-Core hyper-threaded CPUs
 		$familypn="X6275M2";
-	} elsif ($m =~ /Sun .*X6275\b/i ) {
+	} elsif ($m =~ /Sun .*X6275\b/i) {
 		# X6275 has 2 or 4 Quad-Core hyper-threaded CPUs
 		$familypn="X6275";
 	}
@@ -9009,14 +9280,26 @@ sub roundup_memory {
 	for ($val=4096; $val <= 14336; $val += 1024) {
 		$newval=$val if ($newval >= $val-512 && $newval < $val);
 	}
-	for ($val=14336; $val <= 65536; $val += 2048) {
+	for ($val=14336; $val <= 32768; $val += 2048) {
 		$newval=$val if ($newval >= $val-1024 && $newval < $val);
 	}
-	for ($val=65536; $val <= 262144; $val += 4096) {
+	for ($val=32768; $val <= 262144; $val += 4096) {
 		$newval=$val if ($newval >= $val-2048 && $newval < $val);
 	}
-	for ($val=262144; $val <= 16777216; $val += 8192) {
+	for ($val=262144; $val <= 1048576; $val += 8192) {
 		$newval=$val if ($newval >= $val-4096 && $newval < $val);
+	}
+	for ($val=1048576; $val <= 4194304; $val += 16384) {
+		$newval=$val if ($newval >= $val-8192 && $newval < $val);
+	}
+	for ($val=4194304; $val <= 16777216; $val += 32768) {
+		$newval=$val if ($newval >= $val-16384 && $newval < $val);
+	}
+	for ($val=16777216; $val <= 67108864; $val += 65536) {
+		$newval=$val if ($newval >= $val-32768 && $newval < $val);
+	}
+	for ($val=67108864; $val <= 268435456; $val += 131072) {
+		$newval=$val if ($newval >= $val-65536 && $newval < $val);
 	}
 	return($newval);
 }
@@ -9302,7 +9585,7 @@ sub check_dmidecode {
 		($permission_error)=(/(.*)/) if (/Permission denied/i);
 		($dmidecode_error)=(/# *(.*)/) if (/No SMBIOS nor DMI entry point found/i && ! &is_xen_vm);
 		# Detect end of DMI type 17 blocks
-#		&pdebug("TLS In DMI type 17, $_") if ($DMItype == 17);
+#		&pdebug("In DMI type 17, $_") if ($DMItype == 17);
 		if (/(^Handle|^\s*$)/i && $DMItype == 17 && $memarr >= 0 && ! $DMI17end) {
 			$DMI17end=1;
 			$DMItype=0;
@@ -10118,7 +10401,8 @@ sub show_control_LDOM_message {
 	# Post notice if on control LDOM
 	#
 	print "NOTICE: Control Logical Domain (LDOM) detected.  ";
-	if ($picl_foundmemory) {
+	$picl_bank_cnt=scalar(keys %picl_mem_bank);
+	if ($picl_foundmemory || $picl_bank_cnt) {
 		print "The cpus and memory modules\n";
 		print "    reported are for the system, not necessarily the control LDOM.\n";
 	} else {
@@ -10225,7 +10509,7 @@ sub check_cpuinfo {
 			if (/^model name\s*: /) {
 				($cpuinfo_cputype)=(/: (.*)$/);
 				$cpuinfo_cputype=&cleanup_cputype($cpuinfo_cputype);
-				if (/.*(ARM|Feroceon)/) {
+				if (/.*(ARM|Feroceon|Marvell)/) {
 					if ($filename) {
 						# Special case for regression testing
 						$machine="arm";
@@ -10266,7 +10550,7 @@ sub check_cpuinfo {
 			if (($machine !~ /.86|ia64|amd64|sparc/ && ! $filename) || $filename) {
 				if (/^Processor\s+: /) {
 					($cpuinfo_cputype)=(/: (.*)$/);
-					if ($filename && /^Processor\s+: .*(ARM|Feroceon)/) {
+					if ($filename && /^Processor\s+: .*(ARM|Feroceon|Marvell)/) {
 						# Special case for regression testing
 						$machine="arm";
 						$platform=$machine;
@@ -10321,7 +10605,8 @@ sub check_cpuinfo {
 sub finish {
 	&show_header;
 	#print "newslots=@newslots\n" if ($#newslots > 0 && $verbose > 1);
-	if ($isX86) {
+	# Large memory system like SPARC T7-4 can mismatch memory in prtconf and ipmitool
+	if ($isX86 || $ultra =~ /^T7-/) {
 		# smbios and ipmitool memory data is more accurate than prtconf
 		if ($smbios_memory && $smbios_memory > $installed_memory) {
 			$installed_memory=$smbios_memory;
@@ -10333,7 +10618,8 @@ sub finish {
 	}
 	# Cannot accurately determine installed memory unless information is
 	# is in prtpicl output, or if system is fully stuffed
-	if ($ldm_memory && ! $picl_foundmemory) {
+	$picl_bank_cnt=scalar(keys %picl_mem_bank);
+	if ($ldm_memory && ! ($picl_foundmemory || $picl_bank_cnt)) {
 		$totmem=&roundup_memory($installed_memory);
 		&show_total_memory;
 		&show_control_LDOM_message;
@@ -10878,12 +11164,12 @@ sub finish {
 	&show_unrecognized if ($recognized == 0);
 	if (! &is_virtualmachine) {
 		if ($smbios_memory && &roundup_memory($smbios_memory) != $installed_memory) {
-			print "ERROR: Memory found by smbios (${smbios_memory}MB) does not match memory found in $config_command.\n";
+			print "ERROR: Memory found by smbios (${smbios_memory}MB) does not match memory found in $config_command (${installed_memory}MB).\n";
 			print "       This may be corrected by installing a Sun BIOS patch on this system.\n";
 			$exitstatus=1;
 		}
 		if ($ipmi_memory && $ipmi_memory != $installed_memory) {
-			print "ERROR: Memory found by ipmitool (${ipmi_memory}MB) does not match memory found in $config_command.\n";
+			print "ERROR: Memory found by ipmitool (${ipmi_memory}MB) does not match memory found in $config_command (${installed_memory}MB).\n";
 			print "       This may be corrected by installing a Sun BIOS patch on this system.\n";
 			$exitstatus=1;
 		}
@@ -10907,6 +11193,11 @@ sub finish {
 	}
 	# SPARC-M5, SPARC-M6 or other SPARC-M*
 	if ($cputype =~ /SPARC.M\d\+/) {
+		$untested=1;
+		$untested_type="CPU" if (! $untested_type);
+	}
+	# SPARC-S* excluding SPARC-S7
+	if ($cputype =~ /SPARC.S\d\+/ && $cputype !~ /SPARC.S7\b/) {
 		$untested=1;
 		$untested_type="CPU" if (! $untested_type);
 	}
@@ -10991,9 +11282,9 @@ sub b64encodefile {
 sub mailmaintainer {
 	# E-mail information of system to maintainer. Use system call to
 	# sendmail instead of Mail::Send module so that this works for perl4
-	if (-x "/usr/sbin/sendmail") {
+	if (-x '/usr/sbin/sendmail') {
 		$sendmail='/usr/sbin/sendmail';
-	} elsif (-x "/usr/lib/sendmail") {
+	} elsif (-x '/usr/lib/sendmail') {
 		$sendmail='/usr/lib/sendmail';
 	} else {
 		$sendmail="";


### PR DESCRIPTION
Added support for Solaris 11 and for new Oracle Hardware.  Modifications have been tested on Solaris 10 and Solaris 11.  We do not have any systems running older versions of Solaris because Solaris versions prior to Solaris 10 are not supported by Oracle anymore.

List of modifications and enhancements:
- Included newer version of memconf (with support for SPARC T7-4 and S7-2 hardware)
- Modifications in */Ocsinventory/Agent/Backend/OS/Solaris :
    • Bios.pm
        * Add Solaris 11 support
        * Add ldom support (sparc)
        * Use 'ipmitool' to retrieve serial# (sparc)
        * Use 'smbios' to retrieve system information (i386)
    • CPU.pm
        * Add support for additional hardware (T5xxx, T3-x, T4-x, T5-x, T7-x, S7-x, Solaris/x86)
        * Print CPU information for each CPU socket in a server
        * Calculate virtual_cpu from core and thread information
    • Controllers.pm
        * Include description field 
    • Drives.pm
        * Add ZFS support 
    • Memory.pm
        * Add Solaris 11 support
        * Add ldom support (sparc) 
        * Add support for Solaris/x86 on HP ProLiant
    • Slots.pm
        * Add support for additional hardware (280R, 480R, T2000, T5xxx, T3-x,T4-x, T5-x, T7-x, S7-x, Solaris/x86)
    • Storages.pm
        * add ldom support (sparc) 
- Modifications in */Ocsinventory/Agent/Backend/Virtualization :
    •SolarisZones.pm
        * Add Solaris 11 support
        * Retrieve capped-memory info via zonecfg command
        * Retrieve dedicated-cpu info via zonecfg command
        * Retrieve zonetype (native or branded zone)
- Modifications in */Ocsinventory/Agent/Backend/OS/Generic/Packaging :
    • BSDpkg.pm
        * Add Solaris 11 support (both BSD and Solaris11 have a 'pkg' command!) 
- Additions in */Ocsinventory/Agent/Backend/OS/Solaris :
    • Ports.pm
        * Retrieve port information on Solaris/x86 via 'smbios' command (this information is not available on Solaris/sparc)
- Additions in */OCSinventory/Agent/Backend/Virtualization :
    • SolarisLdoms.pm
        * Add ldom support (sparc) 

