### PR TITLE
Add info in PUBLISHER field when getting the list of installed softwares on RPM systems

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/RPM.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/RPM.pm
@@ -22,12 +22,12 @@ sub run {
     my @date;
     my @list;
     my $buff;
-    foreach (`rpm -qa --queryformat "%{NAME}.%{ARCH} %{VERSION}-%{RELEASE} --%{INSTALLTIME}-- --%{SIZE}-- %{SUMMARY}\n--\n" 2>/dev/null`) {
+    foreach (`rpm -qa --queryformat "%{NAME}.%{ARCH} %{VERSION}-%{RELEASE} --%{INSTALLTIME}-- --%{SIZE}-- --%{VENDOR}-- %{SUMMARY}\n--\n" 2>/dev/null`) {
         if (! /^--/) {
             chomp;
             $buff .= $_;
-        } elsif ($buff =~ s/^(\S+)\s+(\S+)\s+--(.*)--\s+--(.*)--\s+(.*)//) {
-            my ($name,$version,$installdate,$filesize,$comments) = ( $1,$2,$3,$4,$5 );
+        } elsif ($buff =~ s/^(\S+)\s+(\S+)\s+--(.*)--\s+--(.*)--\s+--(.*)--\s+(.*)//) {
+            my ($name,$version,$installdate,$filesize,$vendor,$comments) = ( $1,$2,$3,$4,$5,$6 );
             @date = localtime($installdate);
             $installdate = sprintf( "%04d-%02d-%02d %02d:%02d:%02d", $date[5] + 1900, $date[4] + 1, $date[3], $date[2], $date[1], $date[0]);
 
@@ -37,6 +37,7 @@ sub run {
                 'INSTALLDATE'   => $installdate,
                 'FILESIZE'      => $filesize,
                 'COMMENTS'      => $comments,
+                'PUBLISHER'     => $vendor,
                 'FROM'          => 'rpm'
             });
         } else {


### PR DESCRIPTION
This pull request adds the same functionality for RPMs as was added for DEBs in commit 92cff31c30b864ac5e62cd7cee84d79c42a2a8d3.

The publisher info is taken from the RPM VENDOR field which appears to be available in rpm going back to at least 3.0 (from 1999 - see http://rpm.org/timeline.html)

Tested on CentOS 7.3