### PR TITLE
Fix regexp for listing network interfaces on macOS

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Networks.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Networks.pm
@@ -95,7 +95,7 @@ sub run {
     foreach (@ifconfig){
         # skip loopback, pseudo-devices and point-to-point interfaces
         #next if /^(lo|fwe|vmnet|sit|pflog|pfsync|enc|strip|plip|sl|ppp)\d+/;
-        next unless(/^en(0|5)/); # darwin has a lot of interfaces, for this purpose we only want to deal with eth0 and eth1
+        next unless(/^en([0-9])/); # darwin has a lot of interfaces, for this purpose we only want to deal with eth0 and eth1
         if (/^(\S+):/) { push @list , $1; } # new interface name
     }
 


### PR DESCRIPTION
Current regexp only match en0 and en5.
It fixes https://github.com/OCSInventory-NG/UnixAgent/issues/73