### PR TITLE
correct df check

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/AIX/Drives.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/AIX/Drives.pm
@@ -4,7 +4,8 @@ use strict;
 sub check {
     my $params = shift;
     my $common = $params->{common};
-    my $common->can_run("df")
+    return unless $common->can_run("df");
+    1;
 }
 
 sub run {


### PR DESCRIPTION
## Status
**READY**

## Description
Correct this error on AIX :
` [Fri Jun 16 12:21:59 2017][debug] runWithTimeout(): unexpected error: Can't call method "can_run" on an undefined value at /usr/opt/perl5/lib/site_perl/5.10.1/Ocsinventory/Agent/Backend/OS/AIX/Drives.pm line 7.`

## Related Issues
https://github.com/OCSInventory-NG/UnixAgent/issues/77

#### General informations
Operating system :  AIX 7.1
Perl version : 5.10.1

#### OCS Inventory informations
Unix agent version : Ocsinventory unified agent for UNIX, Linux and MacOSX 2.3

## Impacted Areas in Application
Drives inventory
