### PR TITLE
Retrieve info for apfs formatted drive

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Drives.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Drives.pm
@@ -19,7 +19,7 @@ sub run {
     my $volumn;
 
 
-    for my $t ("ffs","ufs", "hfs") {
+    for my $t ("apfs", "ffs","ufs", "hfs") {
   # OpenBSD has no -m option so use -k to obtain results in kilobytes
       for(`df -P -k -t $t`){ # darwin needs the -t to be last
         if(/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\n/){


### PR DESCRIPTION
apfs drives dont show up in the inventory, add apfs to the list

result of 'mount' on an apfs system
/dev/disk1s1 on / (apfs, local, journaled)
/dev/disk1s4 on /private/var/vm (apfs, local, noexec, journaled, noatime, nobrowse)
