### PR TITLE
Fix storage parameters from smartctl

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -310,7 +310,7 @@ sub getFromLsblk {
 
 # get data from smartctl
 sub getFromSmartctl {
-    my ($devices) = @_;
+    my ($params, $devices) = @_;
     my @devs;
     foreach my $device (keys %$devices)     {
         my $vendor         = "";


### PR DESCRIPTION
Commit e287de7f0bd7ba04a1636be09ae72c7c90b80cf4 introduced a bug because
getFromSmartctl is called with two parameters, but only one was assigned,
so $devices got the wrong values.

See also my comments for pull request #95.

Signed-off-by: Stefan Weil <sw@weilnetz.de>