### PR TITLE
Fix code which disables SSL certificate verification

### DIFF
--- a/lib/Ocsinventory/Agent/Network.pm
+++ b/lib/Ocsinventory/Agent/Network.pm
@@ -4,6 +4,7 @@ package Ocsinventory::Agent::Network;
 use strict;
 use warnings;
 
+use IO::Socket::SSL qw(SSL_VERIFY_NONE);
 use LWP::UserAgent;
 use Socket;
 
@@ -70,7 +71,7 @@ sub new {
 
         if ($self->{config}->{ssl} == 0 ) {
             $self->{ua}->ssl_opts(
-                SSL_verify_mode => 'SSL_VERIFY_NONE'
+                SSL_verify_mode => SSL_VERIFY_NONE
             );
         }
     } elsif ($self->{config}->{ssl} eq 1) {


### PR DESCRIPTION
SSL_verify_mode wants a numeric value, not a string,
so replace the string with the predefined constant.

That bug was introduced by commit b4046f4e5a58747c77cf09912edc9c768a89e8a9.

Signed-off-by: Stefan Weil <sw@weilnetz.de>