### PR TITLE
ipdiscover: Fix default latency

### DIFF
--- a/resources/ipdiscover/ipdiscover.h
+++ b/resources/ipdiscover/ipdiscover.h
@@ -41,7 +41,7 @@
 
 #define VERSION 5
 #define NAME_RES_LATENCY 1000000
-#define REQUEST_LATENCY_DEFAULT 100000
+#define REQUEST_LATENCY_DEFAULT 100 /* ms */
 
 /* Trame ARP */
 struct arphdr{


### PR DESCRIPTION
The default latency for the Windows agent is 100 ms
while it was 100 s (!) for Linux.

Now Linux uses 100 ms, too.

Signed-off-by: Stefan Weil <sw@weilnetz.de>