### PR TITLE
UUID.pm :: fix msg "Invalid ..."

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Dmidecode/UUID.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Dmidecode/UUID.pm
@@ -17,6 +17,7 @@ sub run {
     $uuid = `dmidecode -s system-uuid`;
     chomp($uuid);
     $uuid =~ s/^#+\s+$//g;
+    $uuid =~ s/Invalid.*$//g;
 
     $common->setHardware({
         UUID => $uuid,


### PR DESCRIPTION
example:
dmidecode -s system-uuid
00000000-0000-0000-0000-002590C7C000
Invalid entry length (16). Fixed up to 11.

or 

Invalid entry length (0). DMI table is broken! Stop.