### PR TITLE
Rewrite cpu bsd

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
@@ -28,7 +28,7 @@ sub run {
     }
     $processorn = `sysctl -n hw.ncpu`;
     $processort = `sysctl -n hw.model`;
-    
+
     $family = `sysctl -n hw.machine`;
     $serial = `sysctl -n hw.serialno`;
 

--- a/lib/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
@@ -9,40 +9,41 @@ sub check {
 sub run {
     my $params = shift;
     my $common = $params->{common};
-  
+
     my $os;
-  
+
     my $processort;
     my $processorn;
     my $processors;
-    
+
     my $family;
     my $manufacturer;
     my $serial;
-    
+
     chomp($os = `uname -s`);
     if ($os eq "FreeBSD") {
-  	    $processors = `sysctl -n hw.clockrate`;
+        $processors = `sysctl -n hw.clockrate`;
     } else {
-  	    $processors = `sysctl -n hw.cpuspeed`;
+        $processors = `sysctl -n hw.cpuspeed`;
     }
     $processorn = `sysctl -n hw.ncpu`;
     $processort = `sysctl -n hw.model`;
     
     $family = `sysctl -n hw.machine`;
     $serial = `sysctl -n hw.serialno`;
-  
-    if (chomp($processort) =~ /Intel/i) {
-  	    $manufacturer = "Intel";
-    } 
-    if (chomp($processort) =~ /Advanced Micro|AMD/) {
-  	    $manufacturer = "AMD";
+
+    chomp($processort);
+    if ($processort =~ /Intel/) {
+        $manufacturer = "Intel";
     }
-  
+    if ($processort =~ /Advanced Micro|AMD/) {
+        $manufacturer = "AMD";
+    }
+
     $common->addCPU({
         FAMILY => $family,
         MANUFACTURER => $manufacturer,
-        NUMBER => $processorn,
+        CORES => $processorn,
         TYPE => $processort,
         SPEED => $processors,
         SERIAL => $serial


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
READY
Was tested on FreeBSD.

## Description
Rework CPU.pm for BSD. 
Correct  2 bugs for manufacturer :
- delete unneeded caracter
- chomp function return the number of caracters deleted. Added before, it remove return carriage.
Transform var NUMBER in CORES to be parse correctly from the agent.
Remove white space

## Related Issues
No issue

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment

#### General informations
Operating system :  FreeBSD 11.1
Perl version : 5.24

#### OCS Inventory informations
Unix agent version : 2.4


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Correct CPU for BSD
