### PR TITLE
Removal of the current directory (.) from @INC

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,8 @@
+BEGIN {
+    # Avoid installation issue introduced by perl 5.24.1 removing '.' path from
+    # @INC to avoid possible module injection in normal running perl scripts
+    push @INC, '.' if ( $^V && $^V gt 'v5.24' );
+}
 
 use inc::Module::Install;
 
@@ -16,7 +21,7 @@ install :: all pure_install doc_install
 	return $re;
 }
 
-require './lib/Ocsinventory/Agent/Config.pm';
+require 'lib/Ocsinventory/Agent/Config.pm';
 
 use Config;
 


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
Put here all the related issues link

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  Debian Stretch, CentOS 7.4, Fedora 27
Perl version : 5.20.2, 5.16.3, 5.26.1

#### OCS Inventory informations
Unix agent version : ocsinventory unix agent 2.4.1


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1. This modification adds the '.' in @INC variable only if perl version is greater than 5.24. See
http://search.cpan.org/~shay/perl-5.26.2-RC1/pod/perl5241delta.pod#Core_modules_and_tools_no_longer_search_%22.%22_for_optional_modules and http://search.cpan.org/~shay/perl-5.26.2-RC1/pod/perl5260delta.pod for details

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
