### PR TITLE
fallback to mainboard serial if bios serial is not available

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Dmidecode/Bios.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Dmidecode/Bios.pm
@@ -26,6 +26,8 @@ sub run {
     chomp($SystemSerial);
     $SystemSerial =~ s/^(#.*\n)+//g;
     $SystemSerial =~ s/Invalid.*$//g;
+    # System serial number can be filled with whitespace (e.g. Intel NUC)
+    $SystemSerial =~ s/^\s+|\s+$//g;
     chomp($AssetTag);
     $AssetTag =~ s/^(#.*\n)+//g;
     $AssetTag =~ s/Invalid.*$//g;
@@ -62,8 +64,13 @@ sub run {
     chomp($BiosDate);
     $BiosDate =~ s/^(#.*\n)+//g;
     $BiosDate =~ s/Invalid.*$//g;
-  
-  # Some bioses don't provide a serial number so I check for CPU ID (e.g: server from dedibox.fr)
+
+    # If serial number is empty, assign mainboard serial (e.g Intel NUC)
+    if (!$SystemSerial) {
+        $SystemSerial = $MotherboardSerial;
+    }
+
+    # Some bioses don't provide a serial number so I check for CPU ID (e.g: server from dedibox.fr)
     my @cpu;
     if (!$SystemSerial || $SystemSerial =~ /^0+$/) {
         @cpu = `dmidecode -t processor`;


### PR DESCRIPTION
## Status
**READY**

## Description
On Intel NUC machines, the BIOS serial number is empty, or rather consists of whitespace characters. In earlier versions (i.e. 2:2.0.5-1.2 in Debian stretch) the UnixAgent automatically falls back on the CPU ID which at least in the case of the Intel NUCs from 2014 does not help as they all share the same CPU ID.

In the current version in Debian testing (2:2.4.1-2) even the fallback stopped working as it does not catch an all-whitespace BIOS serial number.

This patch will strip all whitespace from the BIOS serial number and, if it equals the empty string, use the board serial number as a fallback.

#### General informations
Operating system :  Debian (various versions)
Perl version : perl 5.24/5.26

#### OCS Inventory informations
Unix agent version : 2.x

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Might change the serial number of a host if the BIOS serial number was empty.
