### PR TITLE
Indicate good value for memory

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/AIX/Mem.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/AIX/Mem.pm
@@ -23,14 +23,9 @@ sub run {
     $memory=0;
     @lsdev=`lsdev -Cc memory -F 'name' -t totmem`;
     for (@lsdev){
-        @lsattr=`lsattr -EOl$_`;
-        for (@lsattr){
-            if (! /^#/){
-                /^(.+):(.+)/;
-                $memory += $2;
-            }
-        }
+        $memory += `lsattr -a size -F value -El$_`;
     }
+
   
     # Paging Space
     @grep=`lsps -s`;


### PR DESCRIPTION




## Status
**READY**

## Description
Proposal of correction #160
Indicate good value for Hardware > Memory on AIX
Using command: lsattr -El mem0 -a size -F value


## Related Issues
#160 

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  AIX
Perl version : 5.24

#### OCS Inventory informations
Unix agent version : 2.4.1


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
Not but only real tested on AIX 7.1 and 7.2.

