### PR TITLE
Send total memory size to inventory object

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
@@ -66,5 +66,11 @@ sub run {
             'CAPTION'       => 'Status: '.$memory->{'dimm_status'},
         });
     }
+
+    # Send total memory size to inventory object
+    my $sysctl_memsize=`sysctl -n hw.memsize`;
+    $common->setHardware({
+        MEMORY =>  $sysctl_memsize / 1024 / 1024,
+    });
 }
 1;


### PR DESCRIPTION
Prior to commit 227c2e7255dbbb9ebf6c647a448699393426d2ea the total memory size
was sent by CPU.pm but Mem.pm was not updated accordingly.
