### PR TITLE
Fix report of gpu mem on macOS 10.13

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Repository/Debian.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Repository/Debian.pm
@@ -6,7 +6,7 @@ use warnings;
 sub check{
     my $params = shift;
     my $common = $params->{common};
-    return unless $common->can_run("apt");
+    return unless $common->can_run("apt-cache");
 }
 
 sub run{

--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Repository/Debian.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Repository/Debian.pm
@@ -6,7 +6,7 @@ use warnings;
 sub check{
     my $params = shift;
     my $common = $params->{common};
-    return unless $common->can_run("apt-cache");
+    return unless $common->can_run("apt");
 }
 
 sub run{

--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Video.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Video.pm
@@ -40,7 +40,13 @@ sub run {
 
     # add the video information
     foreach my $video (@$data){
-        my $memory = $video->{'spdisplays_vram'};
+        my $memory;
+        # macOS 10.13 doesn't have spdisplays_vram but has _spdisplays_vram
+        if (exists($video->{'spdisplays_vram'})) {
+            $memory = $video->{'spdisplays_vram'};
+        } elsif (exists($video->{'_spdisplays_vram'})) {
+            $memory = $video->{'_spdisplays_vram'};
+        }
         $memory =~ s/ MB$//;
 
         $common->addVideo({


### PR DESCRIPTION
macOS 10.13 doesn't have spdisplays_vram but has _spdisplays_vram