### PR TITLE
Check the existence of apt-cache and not apt since we're gonna use ap…

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Repository/Debian.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Repository/Debian.pm
@@ -6,7 +6,7 @@ use warnings;
 sub check{
     my $params = shift;
     my $common = $params->{common};
-    return unless $common->can_run("apt");
+    return unless $common->can_run("apt-cache");
 }
 
 sub run{


### PR DESCRIPTION
Check the existence of apt-cache and not apt since we're gonna use apt-cache.

It fixes an issue on macOS, the apt command exists and ocsinventory tries to use apt-cache:
sh: apt-cache: command not found