### PR TITLE
ca option is for CA certificates bundle not chain

### DIFF
--- a/Changes
+++ b/Changes
@@ -195,7 +195,7 @@ Revision history for Ocsinventory::Agent
        * Download.pm uses LWP useragent initiated by Network.pm for SSL checks 
        * Download.pm uses LWP useragent initiated by Network.pm for info and frags files downloads
        * Network.pm can use LWP version 6 SSL useragent options
-       * New --ca configuration option to specify a CA certificate path for SSL certificate checks 
+       * New --ca configuration option to specify a CA certificates file path for SSL certificate checks
        * New --ssl configuration option to enable/disable SSL certificate checks 
        * Customize SNMP scans using a special XML format received from server 
        * Getting network devices MAC address during SNMP scans

--- a/lib/Ocsinventory/Agent/Config.pm
+++ b/lib/Ocsinventory/Agent/Config.pm
@@ -182,7 +182,7 @@ sub help {
     print STDERR "\t--delaytime	      set a max delay time (in second) if no PROLOG_FREQ is set (".$self->{config}{delaytime}.")\n";
     print STDERR "\t--scan-homedirs     permit to scan home user directories (".$self->{config}{scanhomedirs}.")\n" ;
     print STDERR "\t--ssl=0|1           disable or enable SSL communications check\n" ;
-    print STDERR "\t--ca=FILE           path to CA certificate chain file in PEM format\n" ;
+    print STDERR "\t--ca=FILE           path to CA certificates file in PEM format\n" ;
 
     print STDERR "\n";
     print STDERR "Manpage:\n";

--- a/ocsinventory-agent
+++ b/ocsinventory-agent
@@ -197,11 +197,11 @@ WARNING: beware with user privacy by using this option because it may encounter 
 =item B<--ssl>=I<0|1>
 
 Check SSL communications using a certificate.
-Set to 0 if you want to disable certificate check or 1 to enable (needs CA certificate path in this case) . Default is set to 1. 
+Set to 0 if you want to disable certificate check or 1 to enable (needs CA certificates file path in this case) . Default is set to 1.
 
 =item B<--ca>=I<FILE>
 
-Path to CA certificate chain file in PEM format, for server SSL certificate validation.
+Path to CA certificates file in PEM format, for server SSL certificate validation.
 Set to <your server configuration directory>/cacert.pem by default. 
 
 =item B<--tag>=I<TAG>

--- a/postinst.pl
+++ b/postinst.pl
@@ -80,7 +80,7 @@ Usage :
 \t--debug                       activate debug mode configuration option while installing OCS Inventory NG Unix Unified agent
 \t--logfile=path                set OCS Inventory NG Unix Unified agent log file path (if needed) 
 \t--nossl                       disable SSL CA verification configuration option while installing OCS Inventory NG Unix Unified agent (not recommended)
-\t--ca=path                     set OCS Inventory NG Unix Unified agent CA certificate chain file path
+\t--ca=path                     set OCS Inventory NG Unix Unified agent CA certificates file path
 \t--download                    activate package deployment feature while installing OCS Inventory NG Unix Unified agent
 \t--snmp                        activate SNMP scans feature while installing OCS Inventory NG Unix Unified agent
 \t--now                         launch OCS Inventory NG Unix Unified agent after installation
@@ -212,10 +212,10 @@ unless ($nowizard) {
         $nossl = ask_yn("Do you want disable SSL CA verification configuration option (not recommended) ?", 'n');
     }
 
-    #Set CA certificate path ?
+    #Set CA certificates file path ?
     unless ($config->{ca}) {
-        if (ask_yn("Do you want to set CA certificate chain file path ?", 'y')){ 
-            $config->{ca} = promptUser('Specify CA certificate chain file path', $config->{ca}, '^\/\w+', 'The location must begin with /');
+        if (ask_yn("Do you want to set CA certificates file path ?", 'y')){
+            $config->{ca} = promptUser('Specify CA certificates file path', $config->{ca}, '^\/\w+', 'The location must begin with /');
         }
     }
 


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
The file path from the ca option is passed as SSL_ca_file
inside ssl_opts to LWP::UserAgent.
A "path to a file containing Certificate Authority certificates"
is expected. See: https://metacpan.org/pod/LWP::UserAgent#ssl_opts

A chain works only if the root certificate is included. All other
non CA root certificates are ignored.

## Related Issues
No related issues

## Test environment
Apache 2.4 server and a OCSInverntory-NG Unix Agent.

Tested with a single CA certificate, with many chain combinations and also using system wide certificates bundle (i.e. `/etc/ssl/certs/ca-certificates.crt`). All those options works as long as the signing CA root certificate is included.


## Deploy Notes
Unix Agent works with a PEM file containing only the root CA certificate.
If the file contains many certificates, it verifies only if this needed root CA certificate is included.
If the signing CA root certificate is missing, the client fail to verify the server.


## Impacted Areas in Application
People thinking that `cacert` file is a chain of certificates includes unneeded certificates.

This affects all SSL/TLS communications.
