### PR TITLE
Network.pm: fix error while running with perl v5.28.0

### DIFF
--- a/lib/Ocsinventory/Agent/Network.pm
+++ b/lib/Ocsinventory/Agent/Network.pm
@@ -50,12 +50,12 @@ sub new {
     $version .= exists ($self->{config}->{VERSION})?$self->{config}->{VERSION}:'';
     $self->{ua}->agent($version);
     $self->{config}->{user}.",".
-    $self->{config}->{password}."";
+    my $password = $self->{config}->{password}."";
     $self->{ua}->credentials(
         $uaserver, # server:port, port is needed 
         $self->{config}->{realm},
         $self->{config}->{user},
-        $self->{config}->{password}
+        $password,
     );
 
     #Setting SSL configuration depending on LWP version


### PR DESCRIPTION
## Status
**READY**

## Description
With perl version 5.28.0, running ocsinventory-agent throws following error:

Useless use of concatenation (.) or string in void context at /usr/share/perl5/site_perl/Ocsinventory/Agent/Network.pm line 53.

This commit should fix that.

#### General informations
Operating system :  Arch Linux
Perl version : 5.28.0

#### OCS Inventory informations
Unix agent version : 2.4.2