### PR TITLE
drop pointless statements that generate a perl warning

### DIFF
--- a/lib/Ocsinventory/Agent/Network.pm
+++ b/lib/Ocsinventory/Agent/Network.pm
@@ -49,8 +49,6 @@ sub new {
     my $version = 'OCS-NG_unified_unix_agent_v';
     $version .= exists ($self->{config}->{VERSION})?$self->{config}->{VERSION}:'';
     $self->{ua}->agent($version);
-    $self->{config}->{user}.",".
-    $self->{config}->{password}."";
     $self->{ua}->credentials(
         $uaserver, # server:port, port is needed 
         $self->{config}->{realm},


### PR DESCRIPTION
## Status
**READY**

## Description

Perl 5.28 warns of:
```shell
# Useless use of concatenation (.) or string in void context at /usr/share/perl5/Ocsinventory/Agent/Network.pm line 53.
```

This generates [autopkgtest](http://packaging.ubuntu.com/html/auto-pkg-test.html) failures, so please remove the useless lines.

## Related Issues

https://bugs.debian.org/913108

#### General informations
Operating system :  Linux
Perl version : 5.28

#### OCS Inventory informations
Unix agent version : 2.4.2
