### PR TITLE
Retrieve backplanes SNMP infos

### DIFF
--- a/lib/Ocsinventory/Agent/Common.pm
+++ b/lib/Ocsinventory/Agent/Common.pm
@@ -854,6 +854,20 @@ sub addSnmpNetwork {
     push @{$xmltags->{NETWORKS}},$content;
 }
 
+sub addSnmpBackPlane {
+    my ($self,$args) = @_;
+    my $xmltags = $self->{xmltags};
+    my $content = {};
+
+    foreach my $key (qw/DESCRIPTION FIRMWARE MANUFACTURER REFERENCE SERIALNUMBER TYPE/) {
+        if (exists $args->{$key}) {
+            $content->{$key}[0] = $args->{$key};
+        }
+    }
+
+    push @{$xmltags->{BACKPLANE}},$content;
+}
+
 sub addSnmpCard {
     my ($self,$args) = @_;
     my $xmltags = $self->{xmltags};

--- a/lib/Ocsinventory/Agent/Modules/Snmp/Entity_Mib.pm
+++ b/lib/Ocsinventory/Agent/Modules/Snmp/Entity_Mib.pm
@@ -21,7 +21,7 @@ sub snmp_run {
         #1 => "other",
         #2 => "unknown",
         3 => "chassis",
-        #4 => "backplane",
+        4 => "backplane",
         #5 => "container",
         6 => "powerSupply",
         7 => "fan",
@@ -44,7 +44,7 @@ sub snmp_run {
            my $PhysicalClass=$result_snmp->{$snmp_entPhysicalClass.".".$ref};
  
            my $info = {};
-           if ( $PhysicalClass =~ /^[3,6,7,9,11]$/ ) {
+           if ( $PhysicalClass =~ /^[3,4,6,7,9,11]$/ ) {
                info_element($info,$session,$ref,$logger);
                $info->{TYPE}=$translation_entPhysicalClass->{$PhysicalClass};
                if ( $PhysicalClass == 3 ) {
@@ -52,6 +52,9 @@ sub snmp_run {
                    $nbr_switch++;
                    $common->addSnmpSwitch( $info ); 
                    # Infos for a switch: DESCRIPTION, REFERENCE, REVISION, FIRMWARE, SERIALNUMBER, MANUFACTURER, TYPE
+               } elsif ( $PhysicalClass == 4 ) {
+		   # Infos for the backplane : DESCRIPTION, FIRMWARE MANUFACTURER REFERENCE SERIALNUMBER TYPE
+                   $common->addSnmpBackPlane( $info );
                } elsif ( $PhysicalClass == 6 ) {
                    # Infos for an alimentation DESCRIPTION, REFERENCE, REVISION, SERIALNUMBER, MANUFACTURER, TYPE
                    $common->addSnmpPowerSupply( $info );


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

## Status
**READY**

## Description
Now retrieve SNMP infos for backplanes

#### General informations
Operating system :  Centos7
Perl version : 5.16.3


