### PR TITLE
Fix missing / in installation date

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
@@ -25,7 +25,7 @@ sub run {
     foreach my $file_list (@listfile){
         my $stat=stat($file_list);
         my ($year,$month,$day,$hour,$min,$sec)=(localtime($stat->mtime))[5,4,3,2,1,0];
-        $value=sprintf "%02d/%02d%02d %02d:%02d:%02d",($year+1900),$month,$day,$hour,$min,$sec;
+        $value=sprintf "%02d/%02d/%02d %02d:%02d:%02d",($year+1900),$month,$day,$hour,$min,$sec;
         $key=fileparse($file_list, ".list");
         $key =~ s/(\s+):.+/$1/;
         $statinfo{$key}=$value;


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY

## Description
Fix missing '/' in installation date of debian package

## Related Issues
https://github.com/OCSInventory-NG/UnixAgent/issues/187

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  Fedora 29
Perl version : 5.28.0

#### OCS Inventory informations
Unix agent version : 2.4.1, 2.4.2


## Deploy Notes

## Impacted Areas in Application



