### PR TITLE
Fix issue Service-Pack wrong info on Linux Clients

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/SuSE.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/SuSE.pm
@@ -7,26 +7,26 @@ sub check {
     $common->can_read ("/etc/SuSE-release") 
 }
 
-#####
-sub findRelease {
-    my $v;
-  
-    open V, "</etc/SuSE-release" or warn;
-    chomp ($v=<V>);
-    close V;
-    $v;
-}
-
 sub run {
+    my $v;
+    my $version;
+    my $patchlevel;
+  
     my $params = shift;
     my $common = $params->{common};
   
-    my $OSComment;
-    chomp($OSComment =`uname -v`);
-  
+    open V, "</etc/SuSE-release" or warn;
+    foreach (<V>) {
+        next if (/^#/);
+        $version=$1 if (/^VERSION = ([0-9]+)/);
+        $patchlevel=$1 if (/^PATCHLEVEL = ([0-9]+)/);
+    }
+    close V;
+
     $common->setHardware({ 
-        OSNAME => findRelease(),
-        OSCOMMENTS => "$OSComment"
+        OSNAME => "SUSE Linux Enterprise Server $version SP$patchlevel",
+        OSVERSION => $version,
+        OSCOMMENTS => $patchlevel
     });
 }
 


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY*

## Description
A few sentences describing the overall goals of the pull request's commits.
Service pack level exists in /etc/SuSE-release file. 

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/741

## Todos
- [ ] Tests
- [ ] Documentation

#### General informations
Operating system :  Fedora 30
Perl version : 5.28.

#### OCS Inventory informations
Unix agent version : 2.6.0

