### PR TITLE
Release ocsinventory unified agent v2.6.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for Ocsinventory::Agent
+2.6.0
+       * Fix issue Service-Pack wrong info on Linux Clients (reports on https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/741)
+       * Fix issues #181, #187, #194, #197
+       * Merge PR #175, #178, #190, #191, #193, #196, #199, #201
 
 2.4.2
        * Fix warning argument freebsd isn't numeric

--- a/lib/Ocsinventory/Agent/Config.pm
+++ b/lib/Ocsinventory/Agent/Config.pm
@@ -3,7 +3,7 @@ package Ocsinventory::Agent::Config;
 use strict;
 use Getopt::Long;
 
-our $VERSION = '2.4.2';
+our $VERSION = '2.6.0';
 
 my $basedir = '';
 my $default = {


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
This is the new release of  the unified ocsinventory agent.

## Test environment
Tested on Fedora 30

#### General informations
Operating system :  Fedora 30
Perl version : 5.28.2

#### OCS Inventory informations
Unix agent version : 2.6.0


## Deploy Notes
See Changes file for fixes and enhancements.
