### PR TITLE
Use of /etc/os-release or /etc/SuSE-release

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/SuSE.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/SuSE.pm
@@ -17,28 +17,28 @@ sub run {
     my $common = $params->{common};
 
     if(-s "/etc/os-release"){
-	   open V, "/etc/os-release" or warn;
-	    foreach (<V>) {
-        next if (/^#/);
+	open V, "/etc/os-release" or warn;
+	foreach (<V>) {
+        	next if (/^#/);
 		$osname=$1 if (/^PRETTY_NAME="([A-Z]*[a-z]*[0-9]*.*)"/);
-        $version=$1 if (/^VERSION_ID="([0-9]*.*)"/);
-        $patchlevel=$1 if (/^VERSION="([A-Z]*[0-9]*.*)"/);
+        	$version=$1 if (/^VERSION_ID="([0-9]*.*)"/);
+        	$patchlevel=$1 if (/^VERSION="([A-Z]*[0-9]*.*)"/);
         }
-       close V;
+        close V;
     }else{
-	   open V, "/etc/SuSE-release" or warn;
-	   $osname=<V>;
-	    foreach (<V>) {
-        next if (/^#/);
-        $version=$1 if (/^VERSION = ([0-9]+)/);
-        $patchlevel=$1 if (/^PATCHLEVEL = ([0-9]+)/);
+	open V, "/etc/SuSE-release" or warn;
+	$osname=<V>;
+	foreach (<V>) {
+        	next if (/^#/);
+        	$version=$1 if (/^VERSION = ([0-9]+)/);
+        	$patchlevel=$1 if (/^PATCHLEVEL = ([0-9]+)/);
         }
-       close V;
+        close V;
     }
 
     $common->setHardware({
         OSNAME => $osname,
-		OSVERSION => $version,
+	OSVERSION => $version,
         OSCOMMENTS => $patchlevel
     });
 }

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/SuSE.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/SuSE.pm
@@ -1,31 +1,44 @@
 package Ocsinventory::Agent::Backend::OS::Linux::Distro::NonLSB::SuSE;
 use strict;
 
-sub check { 
+sub check {
     my $params = shift;
     my $common = $params->{common};
-    $common->can_read ("/etc/SuSE-release") 
+    $common->can_read ("/etc/SuSE-release")
 }
 
 sub run {
     my $v;
     my $version;
     my $patchlevel;
-  
+    my $osname;
+
     my $params = shift;
     my $common = $params->{common};
-  
-    open V, "</etc/SuSE-release" or warn;
-    foreach (<V>) {
+
+    if(-s "/etc/os-release"){
+	   open V, "/etc/os-release" or warn;
+	    foreach (<V>) {
+        next if (/^#/);
+		$osname=$1 if (/^PRETTY_NAME="([A-Z]*[a-z]*[0-9]*.*)"/);
+        $version=$1 if (/^VERSION_ID="([0-9]*.*)"/);
+        $patchlevel=$1 if (/^VERSION="([A-Z]*[0-9]*.*)"/);
+        }
+       close V;
+    }else{
+	   open V, "/etc/SuSE-release" or warn;
+	   $osname=<V>;
+	    foreach (<V>) {
         next if (/^#/);
         $version=$1 if (/^VERSION = ([0-9]+)/);
         $patchlevel=$1 if (/^PATCHLEVEL = ([0-9]+)/);
+        }
+       close V;
     }
-    close V;
 
-    $common->setHardware({ 
-        OSNAME => "SUSE Linux Enterprise Server $version SP$patchlevel",
-        OSVERSION => $version,
+    $common->setHardware({
+        OSNAME => $osname,
+		OSVERSION => $version,
         OSCOMMENTS => $patchlevel
     });
 }


### PR DESCRIPTION
## Status
**READY to TEST**

## Description
If exist, the client use the infos from /etc/os-release instead of /etc/SuSE-release
Correct the "OSNAME" from /etc/SuSE-release (if no Enterprise Server)

from /etc/os-release:
![image](https://user-images.githubusercontent.com/8693550/58102788-2aa82a00-7be2-11e9-8b9d-da9de1efa3cc.png)

from /etc/SuSE-release:
![image](https://user-images.githubusercontent.com/8693550/58102834-414e8100-7be2-11e9-9839-f75110ea19e7.png)


## Related Issues
Put here all the related issues link

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
SLES 12 SP4

#### General informations
Operating system : SLES 12 SP4 

#### OCS Inventory informations
Unix agent version : 2.6.0
