### PR TITLE
Suppress unused line 52 $self->{config}->{user}.",". which make a

### DIFF
--- a/lib/Ocsinventory/Agent/Network.pm
+++ b/lib/Ocsinventory/Agent/Network.pm
@@ -49,7 +49,6 @@ sub new {
     my $version = 'OCS-NG_unified_unix_agent_v';
     $version .= exists ($self->{config}->{VERSION})?$self->{config}->{VERSION}:'';
     $self->{ua}->agent($version);
-    $self->{config}->{user}.",".
     my $password = $self->{config}->{password}."";
     $self->{ua}->credentials(
         $uaserver, # server:port, port is needed 


### PR DESCRIPTION

## Status
**READY**

## Description

Remove a warning when launch

## Related Issues

Use of uninitialized value $password in concatenation (.) or string at /usr/share/perl5/Ocsinventory/Agent/Network.pm line 53.

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment

Test on Debian Stretch

#### General informations
Operating system :  Debian Stretch
Perl version : 5.24

#### OCS Inventory informations
Unix agent version : 2.6.0


## Deploy Notes

1. Nothing specific

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Nothing specific
