### PR TITLE
Separation of IPv4 and IPv6 addresses set in hardware

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/IP.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/IP.pm
@@ -12,13 +12,14 @@ sub run {
     my $params = shift;
     my $common = $params->{common};
     my @ip;
+    my @ip6;
 
     if ($common->can_run("ip")){
         foreach (`ip a`){
             if (/inet (\S+)\/\d{1,2}/){
                 ($1=~/127.+/)?next:push @ip,$1;
             } elsif (/inet6 (\S+)\d{2}/){
-                ($1=~/::1\/128/)?next:push @ip, $1;
+                ($1=~/::1\/128/)?next:push @ip6, $1;
             }
         }
     } elsif ($common->can_run("ifconfig")){
@@ -27,14 +28,18 @@ sub run {
             if (/^\s*inet add?r\s*:\s*(\S+)/ || /^\s*inet\s+(\S+)/){
                 ($1=~/127.+/)?next:push @ip, $1;
             } elsif (/^\s*inet6\s+(\S+)/){
-                ($1=~/::1/)?next:push @ip, $1;
+                ($1=~/::1/)?next:push @ip6, $1;
             }
         }
     }
 
     my $ip=join "/", @ip;
+    my $ip6=join "/", @ip6;
     if (defined $ip) {
           $common->setHardware({IPADDR => $ip});
+    } else {
+          $common->setHardware({IPADDR => $ip6});
+          
     }
 }
 


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Separate IPV4 and IPv6 ipaddresses set in hardware table.

## Related Issues
Put here all the related issues link
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/781

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
Tested on Fedora 30

#### General informations
Operating system :  Linux Fedora
Perl version : 5.28.2

#### OCS Inventory informations
Unix agent version : 2.6.0


## Impacted Areas in Application
List general components of the application that this PR will affect:

*
