### PR TITLE
Use of /etc/os-release file for OS infos

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/LSB.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/LSB.pm
@@ -1,5 +1,8 @@
 package Ocsinventory::Agent::Backend::OS::Linux::Distro::LSB;
 
+use vars qw($runMeIfTheseChecksFailed);
+$runMeIfTheseChecksFailed = ["Ocsinventory::Agent::Backend::OS::Linux::Distro::NonLSB"];
+
 sub check {
     my $params = shift;
     my $common = $params->{common};

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB.pm
@@ -1,5 +1,5 @@
 package Ocsinventory::Agent::Backend::OS::Linux::Distro::NonLSB;
 
-$runMeIfTheseChecksFailed = ["Ocsinventory::Agent::Backend::OS::Linux::Distro::LSB"];
+$runMeIfTheseChecksFailed = ["Ocsinventory::Agent::Backend::OS::Linux::Distro::OSRelease"];
 
 1;

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
@@ -1,0 +1,40 @@
+package Ocsinventory::Agent::Backend::OS::Linux::Distro::OSRelease;
+
+use warnings;
+use strict;
+
+sub check {
+    my $params = shift;
+    my $common = $params->{common};
+    $common->can_read ("/etc/os-release") 
+}
+
+sub run {
+
+    my $v;
+    my $name;
+    my $version;
+    my $description;
+
+    my $params = shift;
+    my $common = $params->{common};
+
+    open V, "/etc/os-release" or warn;
+    foreach (<V>) {
+       next if /^#/;
+       $name = $1 if (/^NAME="?([^"]+)"?/);
+       $version = $1 if (/^VERSION_ID="?([^"]+)"?/);
+       $description=$1 if (/^PRETTY_NAME="?([^"]+)"?/);
+    }
+    close V;
+    chomp($name);
+
+    $common->setHardware({
+        OSNAME => $name,
+        OSVERSION => $version,
+        OSCOMMENTS => $description,
+    });
+
+}
+
+1;


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Now use /etc/os-release file to retrieve OS informations.

## Related Issues
#216 https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/741

## Todos

## Test environment
Fedora/CentOS/OpenSuSE/Debian/Ubuntu

#### General informations
Operating system :  Linux Fedora 30
Perl version : 5.28.2 

#### OCS Inventory informations
Unix agent version : 2.6.0

## Impacted Areas in Application
OS informations
