### PR TITLE
Fix issue to retrieve ipdhcp server for Ubuntu

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/Networks.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/Networks.pm
@@ -26,7 +26,7 @@ sub getLeaseFile {
         /var/lib/dhcp
         /var/lib/NetworkManager
     );
-    my @patterns = ("*$if*.lease", "*.lease", "dhclient.leases.$if");
+    my @patterns = ("*$if*.lease", "*.lease*", "dhclient.leases.$if");
     my @files;
 
     foreach my $directory (@directories) {


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Fix bug on retrieving ip dhcp server

## Related Issues
#221 

## Test environment
Ubuntu 18.04.2

#### General informations
Operating system : Fedora 30  
Perl version : 5.28.2

#### OCS Inventory informations
Unix agent version : 2.6.0
