### PR TITLE
Copy cronjob script from Fedora so others can use it

### DIFF
--- a/contrib/cron/ocsinventory-agent.cron
+++ b/contrib/cron/ocsinventory-agent.cron
@@ -1,0 +1,41 @@
+#!/bin/bash
+NAME=ocsinventory-agent
+
+exec >>/var/log/$NAME/$NAME.log 2>&1 
+
+[ -f   /etc/sysconfig/$NAME ] || exit 0
+source /etc/sysconfig/$NAME
+export PATH
+
+i=0
+while [ $i -lt ${#OCSMODE[*]} ]
+do
+	if [ ${OCSMODE[$i]:-none} == cron ]; then
+		OPTS=
+		if [ ! -z "${OCSPAUSE[$i]}" ]; then
+			OPTS="--wait ${OCSPAUSE[$i]}"
+		fi
+
+		if [ ! -z "${OCSTAG[$i]}" ]; then
+		        OPTS="$OPTS --tag=${OCSTAG[$i]}"
+		fi
+
+		if [ "z${OCSSERVER[$i]}" = 'zlocal' ]; then
+	        	# Local inventory
+	        	OPTS="$OPTS --local=/var/lib/$NAME"
+
+		elif [ ! -z "${OCSSERVER[$i]}" ]; then
+	        	# Remote inventory
+		        OPTS="$OPTS --lazy --nolocal --server=${OCSSERVER[$i]}"
+		        if [ ! -z "${OCSPROXYSERVER[$i]}" ]; then
+		        	OPTS="$OPTS --proxy=${OCSPROXYSERVER[$i]}"
+		        fi
+		fi
+
+		echo "[$(date '+%c')] Running $NAME $OPTS"
+		/usr/sbin/$NAME  $OPTS
+	fi
+	((i++))
+done
+echo "[$(date '+%c')] End of cron job ($PATH)"
+

--- a/contrib/cron/ocsinventory-agent.sysconf
+++ b/contrib/cron/ocsinventory-agent.sysconf
@@ -1,0 +1,26 @@
+## 
+## OCS Inventory "Unix Unified Agent" Configuration File
+## used by the supplied cron job
+##
+
+## Add tools directory if needed (tw_cli, hpacucli, ipssend, ...)
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+
+## Mode, change to "cron" to activate
+OCSMODE[0]=none
+
+## can be used to override the ocsinventory-agent.cfg setup.
+# OCSSERVER[0]=your.ocsserver.name
+#
+## If you need an HTTP/HTTPS proxy, fill this out
+# OCSPROXYSERVER[0]='http://user:pass@proxy:port'
+## 
+## corresponds with --local=/var/lib/ocsinventory-agent
+OCSSERVER[0]=local
+
+## Wait before inventory 
+OCSPAUSE[0]=100
+
+## Administrative TAG (optional, must be filed before first inventory)
+OCSTAG[0]=
+

--- a/contrib/cron/systemd/ocsinventory-agent-daily.timer
+++ b/contrib/cron/systemd/ocsinventory-agent-daily.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run OCS Inventory once per day
+
+[Timer]
+OnCalendar=daily
+OnUnitInactiveSec=86000
+
+Unit=ocsinventory-agent.service
+RandomizedDelaySec=900
+AccuracySec=900
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/contrib/cron/systemd/ocsinventory-agent-hourly.timer
+++ b/contrib/cron/systemd/ocsinventory-agent-hourly.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run OCS Inventory Hourly (if server permits)
+
+[Timer]
+OnCalendar=hourly
+Unit=ocsinventory-agent.service
+RandomizedDelaySec=10
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/contrib/cron/systemd/ocsinventory-agent-onboot.timer
+++ b/contrib/cron/systemd/ocsinventory-agent-onboot.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run OCS Inventory shortly after boot
+
+[Timer]
+OnBootSec=900
+Unit=ocsinventory-agent.service
+RandomizedDelaySec=10
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/contrib/cron/systemd/ocsinventory-agent.service
+++ b/contrib/cron/systemd/ocsinventory-agent.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=OCS Inventory Agent
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/ocsinventory-agent/ocsinventory-agent.cron
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Status
READY

## Description
Copy the Fedora cronjob into `contrib` so other Unix systems can utilize it if desired.  Some sample systemd unit files are provided for folks who would rather use systemd timers rather than `/etc/cron.X`

Various Unix systems have various ways of run the automated reporting.  This PR will provide a theoretical 'default' approach for unifying the approach across various distributions.

## Related Issues
None

## Todos
- [x] Tests
- [x] Documentation

## Testing
This is the exact script in the existing Fedora RPMs.

#### General informations
Operating system :  Fedora
Perl version : 5.30.0

#### OCS Inventory informations
Unix agent version : 2.6.0


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
