### PR TITLE
Update Oracle.pm

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/Oracle.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/NonLSB/Oracle.pm
@@ -1,4 +1,4 @@
-package Ocsinventory::Agent::Backend::OS::Linux::Distro::NonLSB::oracle;
+package Ocsinventory::Agent::Backend::OS::Linux::Distro::NonLSB::Oracle;
 use strict;
 
 sub check {-f "/etc/oracle-release"}


### PR DESCRIPTION
unable to run due to lower case "o" not matching with module naming

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
unable to run due to module naming difference.

## Related Issues
Put here all the related issues link

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  Oracle
Perl version :

#### OCS Inventory informations
Unix agent version : 2.4.2


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
