### PR TITLE
Fixbug ovirt machines not listed

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/Virtualization/Libvirt.pm
+++ b/lib/Ocsinventory/Agent/Backend/Virtualization/Libvirt.pm
@@ -14,7 +14,7 @@ sub run {
     my $params = shift;
     my $common = $params->{common};
 
-    foreach (`virsh list --all`) {
+    foreach (`virsh --readonly list --all`) {
         if (/^\s*(\d+|\s+\-)\s+(\S+)\s+(\S.+)/){
             my $memory;
             my $vcpu;
@@ -22,7 +22,7 @@ sub run {
             my $status = $3;
 
             $status =~ s/^shut off/off/;
-            my $xml = `virsh dumpxml $name`;
+            my $xml = `virsh --readonly dumpxml $name`;
             my $data = XMLin($xml);
 
             my $vcpu = $data->{vcpu};

--- a/lib/Ocsinventory/Agent/Backend/Virtualization/Libvirt.pm
+++ b/lib/Ocsinventory/Agent/Backend/Virtualization/Libvirt.pm
@@ -37,7 +37,7 @@ sub run {
                 $vcpu = $data->{vcpu};
             }
 
-            my $machine = {
+            my %machine = (
                 MEMORY => $memory,
                 NAME => $name,
                 UUID => $uuid,
@@ -45,9 +45,9 @@ sub run {
                 SUBSYSTEM => "Libvirt",
                 VMTYPE => $vmtype,
                 VCPU   => $vcpu,
-            };
+            );
 
-            $common->addVirtualMachine($machine);
+            $common->addVirtualMachine(\%machine);
 
         }
     }


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
A few sentences describing the overall goals of the pull request's commits.
Machines hosted on an ovirt-engine (libvirt) are not listed in the item representing the hypervisor.
The Miscellaneous menu is empty.

## Related Issues
na

## Todos
- [x] Tests
- [x] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs
tested on an ovirt engine with 40 virtual machines hosted.

#### General informations
Operating system :  centos 7.x
Perl version : v5.16.3

#### OCS Inventory informations
Unix agent version : 2.3.1


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes, logical changes, etc.

1. nothing really

## Impacted Areas in Application
List general components of the application that this PR will affect:

* libvirt
