### PR TITLE
Add message if no output target set

### DIFF
--- a/lib/Ocsinventory/Agent.pm
+++ b/lib/Ocsinventory/Agent.pm
@@ -143,7 +143,10 @@ sub run {
         }
     } elsif (defined($config->{config}{local}) && $config->{config}{local}) {
         $config->{config}{vardir} = $config->{config}{basevardir}."/__LOCAL__";
+    } else {
+        $logger->error("You must set either --server or --local");
     }
+
 
     if (!recMkdir ($config->{config}{vardir})) {
         $logger->error("Failed to create ".$config->{config}{vardir}." directory: $!");


### PR DESCRIPTION
## Status
**READY**

## Description
This provides a fall through message if neither `--server` or `--local` are set when running the client.

## Related Issues
None

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  
Perl version :

#### OCS Inventory informations
Unix agent version :


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
