### PR TITLE
Permit storing CA list in config dir

### DIFF
--- a/lib/Ocsinventory/Agent.pm
+++ b/lib/Ocsinventory/Agent.pm
@@ -158,7 +158,18 @@ sub run {
 
     # Setting SSL CA file path if not set in configuration
     unless ($config->{config}{ca}) {
-        $config->{config}{ca} = $config->{config}{vardir}."/cacert.pem";
+        # use server specific cacert.pem if it exists
+        $config->{config}{ca} = $config->{config}{vardir}.'/cacert.pem';
+
+        # if no server specific cacert.pem, look for a bundle in our config dir
+        unless (-e $config->{config}{vardir}.'/cacert.pem') {
+            foreach (@{$config->{config}{etcdir}}) {
+                if (-e $_.'/ocsinventory-agent-cacert.pem') {
+                    $config->{config}{ca} = $_.'/ocsinventory-agent-cacert.pem';
+                    last;
+                }
+            }
+        }
     }
 
 ################################################################################################################


### PR DESCRIPTION
# #  Status
**READY**

## Description
This PR adds a default place for admins to deploy a CA store for their OCS Servers. Existing users should see no behavior change, but new deployments should have an easier time getting the SSL certs in place as there is a central location they can pre-seed trusted CAs.

Unlike my previous PR this does not utilize the system CA and requires admins to select trusted CAs.

## Related Issues
None

## Todos
- [x] Tests
- [X] Documentation

## Test environment
Tested on Fedora, Debian, and Arch Linux

#### General informations
Operating system :  Fedora 30
Perl version : 5.30.0

#### OCS Inventory informations
Unix agent version : 2.6.0


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes, logical changes, etc.

 If a `ocsinventory-agent-cacert.pem` is deployed in the `etc dir` it will be used as the CA cert by for all servers by default.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* HTTPS communications
