### PR TITLE
disk and video card fix if lshw and nvidia-smi present

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm
@@ -213,7 +213,8 @@ sub getFromLshw {
     }
     my $xml = new XML::Simple;
     my $data = $xml->XMLin($input);
-    my $nodes = $data->{list}->{node};
+#    my $nodes = $data->{list}->{node};
+    my $nodes = $data->{list};
 
     foreach my $device (sort keys %$nodes) {
         my $description = "";


### PR DESCRIPTION
Fix getFromLshw XML nodes ( lib/Ocsinventory/Agent/Backend/OS/Linux/Storages.pm )
   disk not in inventory if lshw present :

   my $nodes = $data->{list}->{node} represent node and not nodeslist

Fix nvidia card not present if nvidia-smi is detected  ( lib/Ocsinventory/Agent/Backend/OS/Generic/Lspci/Videos.pm )