### PR TITLE
Do not kill program if no download config

### DIFF
--- a/lib/Ocsinventory/Agent/Modules/Download.pm
+++ b/lib/Ocsinventory/Agent/Modules/Download.pm
@@ -367,7 +367,7 @@ sub download_end_handler{        # Get global structure
         #TODO Uncomment this line #undef $packages;
 
         # Reading configuration
-        open FH, "$dir/config" or die("Cannot read config file: $!");
+        open FH, "$dir/config";
         if (flock(FH, LOCK_SH)){
             $download_config = XMLin("$dir/config");
             close(FH);
@@ -377,8 +377,12 @@ sub download_end_handler{        # Get global structure
                 finish($logger, $context);
             }
         } else {
-            $logger->error("Cannot read config file :-( . Exiting.");
             close(FH);
+            if (-e "$dir/config") {
+                $logger->error("Cannot read config file :-( . Exiting.");
+            } else {
+                $logger->debug("Download not configured");
+            }
             finish($logger, $context);
         }
 


### PR DESCRIPTION
## Status
**READY**

## Description
The download module currently exits with an error if the Server supports downloads but the client doesn't have any thing set to pull in.

This change allows the agent to gracefully fall back and note the issue where necessary.

## Related Issues
None

## Todos
- [x] Tests
- [x] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  Fedora
Perl version : 5.30

#### OCS Inventory informations
Unix agent version : 2.6.0


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1. Errors in the deployment/download are now logged rather than aborting the agent

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Deployment
* Download
