### PR TITLE
Crypt user and password in base64

### DIFF
--- a/postinst.pl
+++ b/postinst.pl
@@ -5,6 +5,7 @@ use strict;
 use lib 'lib';
 
 use Cwd;
+use MIME::Base64;
 use Ocsinventory::Agent::Config;
 
 
@@ -161,8 +162,10 @@ unless ($nowizard) {
 
     #Getting credentials if needed
     if (ask_yn ("Do you need credential for the server? (You probably don't)", 'n')) {
-        $config->{user} = promptUser("user", $config->{user});
+        $config->{user} = (promptUser("user", $config->{user});
+        $config->{user} = MIME::Base64::encode_base64($config->{user});
         $config->{password} = promptUser("password");
+        $config->{password} = MIME::Base64::encode_base64($config->{password});
         print "[info] The realm can be found in the login popup of your Internet browser.\n[info] In general, it's something like 'Restricted Area'.\n";
         $config->{realm} = promptUser("realm");
     }


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
This PR permits to crypt user, password and store them in ocsinventory-agent.cfg file

## Related Issues

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment

#### General informations
Operating system :  linux fedora 31, centos 8
Perl version : 5.30.1

#### OCS Inventory informations
Unix agent version : 2.6.0

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

## Impacted Areas in Application
List general components of the application that this PR will affect:
