### PR TITLE
fixed warnings

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
@@ -57,7 +57,7 @@ sub run {
                 'NAME'          => $deb[0],
                 'ARCHITECTURE'  => $deb[1],
                 'VERSION'       => $deb[2],
-                'FILESIZE'      => $deb[3]*1024,
+                'FILESIZE'      => ( $deb[3] || 0 ) * 1024,
                 'PUBLISHER'     => $deb[5],
                 'INSTALLDATE'   => $statinfo{$key},
                 'COMMENTS'      => $deb[6],

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/Networks.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/Networks.pm
@@ -58,7 +58,7 @@ sub _ipdhcp {
 
     $leasepath = getLeaseFile($if);
 
-    if ( $leasepath =~ /internal/ ) {
+    if ( $leasepath and $leasepath =~ /internal/ ) {
         if (open DHCP, $leasepath) {
             while(<DHCP>) {
                 if (/SERVER_ADDRESS=(\d{1,3}(?:\.\d{1,3}){3})/) {
@@ -69,7 +69,7 @@ sub _ipdhcp {
         } else {
             warn ("Can't open $leasepath\n");
         }
-    } else {
+    } elsif( $leasepath ) {
         if (open DHCP, $leasepath) {
             my $lease;
             while(<DHCP>){


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Fix some warnings about dhcp lease and debian package repository gathering

## Related Issues
Issue 291

Warnings fixed :
- Argument "" isn't numeric in multiplication (*) at /usr/local/share/perl/5.28.1/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm line 62.

- Use of uninitialized value $leasepath in pattern match (m//) at /usr/local/share/perl/5.24.1/Ocsinventory/Agent/Backend/OS/Linux/Network/Networks.pm line 61.
Use of uninitialized value $leasepath in open at /usr/local/share/perl/5.24.1/Ocsinventory/Agent/Backend/OS/Linux/Network/Networks.pm line 73.
Use of uninitialized value $leasepath in concatenation (.) or string at /usr/local/share/perl/5.24.1/Ocsinventory/Agent/Backend/OS/Linux/Network/Networks.pm line 91.

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
Tested with Unix agent version 2.6.1 on Debian stretch

#### General informations
Operating system :  Debian Stretch (9)
Perl version :

#### OCS Inventory informations
Unix agent version : 2.6.1


