### PR TITLE
Fix memory description reporting on macOS

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
@@ -54,6 +54,7 @@ sub run {
         my $desc = $memory->{'dimm_part_number'};
         if ($desc !~ /empty/) {
             # dimm_part_number is an hex string, convert it to ascii
+            $desc = $desc =~ s/^0x//;
             $desc = pack "H*", $desc;
             $desc =~ s/\s+$//;
         }


### PR DESCRIPTION
I don't know what has changed but macOS inventory reporting doesn't work anymore (the server is on FreeBSD).
This patch fixes the issue.