### PR TITLE
Fix failliur to detect the correct version of app-portage/gentoolkit …

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Gentoo.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Gentoo.pm
@@ -18,8 +18,9 @@ sub run {
 
     my $equery_vers = `equery --version ` =~ /.*\((.*)\).*/;
     $equery_vers = $1;
+    my ($major,$minor)=$equery_vers=~/(\d+)\.(\d+)\.\d+/;
 
-    if ($equery_vers =~ /^0.3/) {
+    if ($minor ge 3) {
         foreach (`equery list --format='\$cp \$fullversion' '*'`){
             if (/^(.*) (.*)/) {
                 $common->addSoftware({


### PR DESCRIPTION
…on gentoo

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Fix the issue

## Related Issues
#309

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  Linux 5.4.72-gentoo
Perl version : 5.30.3

#### OCS Inventory informations
Unix agent version : 2.8.1


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
