### PR TITLE
Fix timeout from last command

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Users.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Users.pm
@@ -9,7 +9,7 @@ sub check {
 
     # Useless check for a posix system i guess
     my @who = `who 2>/dev/null`;
-    my @last = `last 2>/dev/null`;
+    my @last = `last -n 1 2>/dev/null`;
 
     if (($common->can_read("/etc/passwd") && $common->can_read("/etc/group")) || @who || @last ) {
         return 1;
@@ -122,7 +122,7 @@ sub _getLast {
     
     my ($lastuser,$lastlogged);
 
-    my @info=`last`;
+    my @info=`last -n 50`;
 
     foreach my $last (@info) {
         chomp $last;

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux.pm
@@ -14,7 +14,7 @@ sub run {
 
     my $lastloggeduser;
     my $datelastlog;
-    my @query = $common->runcmd("last -R");
+    my @query = $common->runcmd("last -R -n 1");
 
     foreach ($query[0]) {
         if ( s/^(\S+)\s+\S+\s+(\S+\s+\S+\s+\S+\s+\S+)\s+.*// ) {


### PR DESCRIPTION
This commit add '-n' option to command 'last' to prevent timeout, as
discussed in the issue #333

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Fix timeout problem from `last` command when the system has a large `/var/log/wtmp` file.

## Related Issues
https://github.com/OCSInventory-NG/UnixAgent/issues/333

## Todos
- [x] Tests
- [x] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  Unix
Perl version : All

#### OCS Inventory informations
Unix agent version : All
