### PR TITLE
Fix Empty value for IPADDR when address contains 127.

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/AIX/IPv4.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/AIX/IPv4.pm
@@ -16,7 +16,7 @@ sub run {
     # AIX need -a option
     for (`ifconfig -a`){#ifconfig in the path
         # AIX ligne inet
-        if(/^\s*inet\s+(\S+).*/){($1=~/127.+/)?next:push @ip, $1};
+        if(/^\s*inet\s+(\S+).*/){($1=~/^127.+/)?next:push @ip, $1};
     }
     $ip=join "/", @ip;
     $common->setHardware({IPADDR => $ip});

--- a/lib/Ocsinventory/Agent/Backend/OS/BSD/IPv4.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/BSD/IPv4.pm
@@ -16,7 +16,7 @@ sub run {
     # *BSD need -a option
     foreach (`ifconfig -a`){
         if (/^\s*inet\s+(\S+)/){
-            ($1=~/127.+/)?next:push @ip, $1
+            ($1=~/^127.+/)?next:push @ip, $1
         };
     }
   

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/IP.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Network/IP.pm
@@ -17,7 +17,7 @@ sub run {
     if ($common->can_run("ip")){
         foreach (`ip a`){
             if (/inet (\S+)\/\d{1,2}/){
-                ($1=~/127.+/)?next:push @ip,$1;
+                ($1=~/^127.+/)?next:push @ip,$1;
             } elsif (/inet6 (\S+)\d{2}/){
                 ($1=~/::1\/128/)?next:push @ip6, $1;
             }
@@ -26,7 +26,7 @@ sub run {
         foreach (`ifconfig`){
             #if(/^\s*inet\s*(\S+)\s*netmask/){
             if (/^\s*inet add?r\s*:\s*(\S+)/ || /^\s*inet\s+(\S+)/){
-                ($1=~/127.+/)?next:push @ip, $1;
+                ($1=~/^127.+/)?next:push @ip, $1;
             } elsif (/^\s*inet6\s+(\S+)/){
                 ($1=~/::1/)?next:push @ip6, $1;
             }

--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/IPv4.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/IPv4.pm
@@ -18,7 +18,7 @@ sub run {
     # *BSD need -a option
     foreach (`ifconfig -a`){
       if(/^\s*inet\s+(\S+)/){
-        ($1=~/127.+/)?next:push @ip, $1
+        ($1=~/^127.+/)?next:push @ip, $1
       };
     }
 

--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/IPv4.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/IPv4.pm
@@ -18,7 +18,7 @@ sub run {
     # Solaris need -a option
     for (`ifconfig -a`){#ifconfig in the path
         #Solarisligne inet
-       if (/^\s*inet\s+(\S+).*/){($1=~/127.+/)?next:($ip{$1}=1)};
+       if (/^\s*inet\s+(\S+).*/){($1=~/^127.+/)?next:($ip{$1}=1)};
     }
 
     # Ok. Now, we have the list of IP addresses configured


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
Put here all the related issues link

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  fedora 33 
Perl version : 5.32.1

#### OCS Inventory informations
Unix agent version : 2.8.1


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
