### PR TITLE
Fix bug group members displaying as HASH

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Users.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Users.pm
@@ -103,14 +103,12 @@ sub _getLocalGroups {
          next if $line =~ /^#/;
          chomp $line;
          my ($name, undef, $gid, $members) = split(/:/, $line);
-
          next unless $members;
-         my @members = split(/,/, $members);
             
          push @groups, {
              ID_GROUP   => $gid,
              NAME       => $name,
-             MEMBER     => \@members,
+             MEMBER     => $members,
          };
      }
 


### PR DESCRIPTION
## Status
**READY**

## Description
The current way of processing the group members in OCS Unix agent make them show as "Hash" 

#### General informations
Operating system :  All
Perl version : All

#### OCS Inventory informations
Unix agent version : Latest