### PR TITLE
CentOS correct release version + update comment

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
@@ -43,7 +43,7 @@ sub run {
     if (-r "/etc/centos-release") {
         open V, "/etc/centos-release" or warn;
         foreach (<V>) {
-            my $version = $1 if ($_ =~ /(\d+\.\d+)./g);
+            $version = $1 if ($_ =~ /(\d+\.\d+)./g);
         }
         close V;
         chomp($version);

--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
@@ -42,11 +42,12 @@ sub run {
     # CentOS exact version number is set in /etc/centos-release file
     if (-r "/etc/centos-release") {
         open V, "/etc/centos-release" or warn;
-        foreach (<V>) {
+        foreach ($description=<V>) {
             $version = $1 if ($_ =~ /(\d+\.\d+)./g);
         }
         close V;
         chomp($version);
+        chomp($description);
     }
 
     $common->setHardware({


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
- Remove the "my" that block the update of "version" variable.
- Update the "description" with the full os version of CentOS.

## Related Issues
- The "my" block the update of "version" variable.
- The "description" doesn't contain the release version.

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
Test was done in large parc of RHEL 7, RHEL 8, CentOS 7, CentOS 8 without problem.

#### General informations
Operating system :  
Perl version :

#### OCS Inventory informations
Unix agent version :


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
