### PR TITLE
Fix the bug to print member in Unix Local Groups

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Users.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Users.pm
@@ -104,11 +104,12 @@ sub _getLocalGroups {
          chomp $line;
          my ($name, undef, $gid, $members) = split(/:/, $line);
          next unless $members;
-            
+         my @members = split(/,/, $members);
+
          push @groups, {
              ID_GROUP   => $gid,
              NAME       => $name,
-             MEMBER     => $members,
+             MEMBER     => \@members,
          };
      }
 


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
The webconsole doesn't display the member in the array Unix local groups

## Related Issues
Put here all the related issues link

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  
Perl version :

#### OCS Inventory informations
Unix agent version :


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
