### PR TITLE
Fixed VirtualBox Script to Fetch VMs For The Current User

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/Virtualization/VirtualBox.pm
+++ b/lib/Ocsinventory/Agent/Backend/Virtualization/VirtualBox.pm
@@ -1,7 +1,5 @@
 package Ocsinventory::Agent::Backend::Virtualization::VirtualBox;
 
-# This module detects only all VMs create by the user who launch this module (root VMs).
-
 use strict;
 
 use XML::Simple;
@@ -30,6 +28,13 @@ sub run {
     my $mem;
     my $status;
     my $name;
+
+    my $current_user = `printenv SUDO_USER`; # fetch the current user
+    chomp ($current_user);
+
+    if (!($current_user eq "")){ # use the current user if it is present
+        $cmd_list_vms = "sudo -u $current_user $cmd_list_vms";
+    }
         
     foreach my $line (`$cmd_list_vms`){                 # read only the information on the first paragraph of each vm
         chomp ($line);


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Virtualbox stores a list of VMs separately for each user. Since the unix agent is run as root, OCS returns the list of VMs for the root user (which is often empty).

This is undesirable since the VMs the user is looking for are more likely to be installed for the current user and not root.

I've fixed this by running the command as the current user instead of root, so that the proper list of VMs is returned.

## Related Issues
#384 

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :  
Perl version :

#### OCS Inventory informations
Unix agent version :


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
