### PR TITLE
Fix addInput missing keys

### DIFF
--- a/lib/Ocsinventory/Agent/Common.pm
+++ b/lib/Ocsinventory/Agent/Common.pm
@@ -200,7 +200,7 @@ sub addInput {
 
     my $content = {};
 
-    foreach my $key (qw/DESCRIPTION INTERFACE MANUFACTURER SERIAL TYPE/) {
+    foreach my $key (qw/DESCRIPTION INTERFACE MANUFACTURER CAPTION POINTTYPE TYPE/) {
         if (exists $args->{$key}) {
             $content->{$key}[0] = $args->{$key} if $args->{$key};
         }


### PR DESCRIPTION
Making INPUT keys match actual [ocsbase.sql](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/4dc83a01a4cd24c7386086d51850cb215860ee1b/files/ocsbase.sql#L1226)

## Status
**READY**

## Description
Making INPUT keys match actual ocsbase.sql
