### PR TITLE
Prevent misunderstanding of version option from config file

### DIFF
--- a/lib/Ocsinventory/Agent/Config.pm
+++ b/lib/Ocsinventory/Agent/Config.pm
@@ -43,7 +43,7 @@ my $default = {
 
     # Other values that can't be changed with the
     # CLI parameters
-    'VERSION'   => $VERSION,
+    'version'   => $VERSION,
     'deviceid'  => '',
     'basevardir'=>  $basedir.'/var/lib/ocsinventory-agent',
     'logdir'    =>  $basedir.'/var/log/ocsinventory-agent',
@@ -146,7 +146,7 @@ sub loadUserParams {
 	);
 
 	$self->help() if (!GetOptions(%options) || $self->{config}{help});
-	$self->version() if $self->{config}{version};
+	$self->version() if $self->{config}{version} eq 1;
 }
 
 

--- a/lib/Ocsinventory/Agent/Network.pm
+++ b/lib/Ocsinventory/Agent/Network.pm
@@ -50,7 +50,7 @@ sub new {
         $self->{ua}->env_proxy;
     }
     my $version = 'OCS-NG_unified_unix_agent_v';
-    $version .= exists ($self->{config}->{VERSION})?$self->{config}->{VERSION}:'';
+    $version .= exists ($self->{config}->{version})?$self->{config}->{version}:'';
     my $userencrypt = Ocsinventory::Agent::Encrypt::getClearText($self->{config}->{user});
     my $pwdencrypt = Ocsinventory::Agent::Encrypt::getClearText($self->{config}->{password});
     $self->{ua}->agent($version);

--- a/lib/Ocsinventory/Logger.pm
+++ b/lib/Ocsinventory/Logger.pm
@@ -38,7 +38,7 @@ sub new {
     }
     
     my $version = "Ocsinventory unified agent for UNIX, Linux and MacOSX ";
-    $version .= exists ($self->{config}->{VERSION})?$self->{config}->{VERSION}:'';
+    $version .= exists ($self->{config}->{version})?$self->{config}->{version}:'';
     $self->debug($version."\n");
     $self->debug("Log system initialised (@loadedMbackends)");
 


### PR DESCRIPTION
- Now that all settings are lowercase adding the version option to the config file make agent think that --version option is passed
- Prevent this behavior checking specifically if the version option is equal to 1
- Change occurrences from VERSION to version

## Status
**READY**