### PR TITLE
remove forbidden char in XML

### DIFF
--- a/lib/Ocsinventory/Agent/Common.pm
+++ b/lib/Ocsinventory/Agent/Common.pm
@@ -1050,6 +1050,7 @@ sub cleanXml {
     my $logger = $self->{logger};
 
     my $clean_content = encode('UTF-8', $content, Encode::FB_DEFAULT | Encode::LEAVE_SRC | Encode::FB_XMLCREF);
+    $clean_content =~ tr/\x00-\x08\x0B\x0C\x0E-\x1F//d;  # remove forbidden char in XML
 
     $logger->debug("cleanXml changed content") if ($content ne $clean_content);
 


### PR DESCRIPTION


## Status
READY

## Description
In some use cases, inventory modules could write forbidden char for XML file.
So the XML inventory upload fail from server with error 500.
We have seen that on only 1 deskop computer (Ubuntu) with monitors module with char 0x0 and 0x5 in XML tag "<CAPTION>" but any module could have same issue.

## Related Issues
None

## Todos
- [X] Tests

## Test environment
You can check/test corrupted inventory joined (corrupted_inventory.xml). I have removed all unnecessary data from it.

#### General informations
Operating system :  Ubuntu 20.04
Perl version : 5.30.0-9ubuntu0.2

#### OCS Inventory informations
Unix agent version : 2:2.8-2


## Deploy Notes
[corrupted-inventory.xml.tar.gz](https://github.com/OCSInventory-NG/UnixAgent/files/7899009/corrupted-inventory.xml.tar.gz)

This patch is already deploy on thousands computers in our company.

## Impacted Areas in Application
This change will add an addition cleaning of XML before sent it to server.

