### PR TITLE
Fix packager not creating agent config file

### DIFF
--- a/macosx/ocsinventory_packages_setup/OCS Inventory Pkg Setup.pkgproj
+++ b/macosx/ocsinventory_packages_setup/OCS Inventory Pkg Setup.pkgproj
@@ -470,8 +470,10 @@
 				</dict>
 				<key>PREINSTALL_PATH</key>
 				<dict>
+					<key>PATH</key>
+					<string>scripts/preinstall</string>
 					<key>PATH_TYPE</key>
-					<integer>0</integer>
+					<integer>1</integer>
 				</dict>
 				<key>RESOURCES</key>
 				<array/>

--- a/macosx/ocsinventory_packages_setup/scripts/preinstall
+++ b/macosx/ocsinventory_packages_setup/scripts/preinstall
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+#Setting path to package resources directory
+RESOURCES=$1/Contents/Resources
+# resources path if off
+
+#Setting path to package resources directory
+BASERESOURCES=$(dirname "$1")
+RESOURCES="$BASERESOURCES/../Resources"
+
+
+
+#Setting temp directory
+if [ $3 ]  #If run from NetInstall
+then
+  TMP_DIR=$3/tmp/ocs_installer
+else
+  TMP_DIR=/tmp/ocs_installer
+fi
+
+echo "preinstall from agent"
+echo $RESOURCES
+echo $TMP_DIR
+#Files we want to copy
+AGENT_CFG_PATH="ocsinventory-agent.cfg"
+MODULES_CFG_PATH="modules.conf"
+LAUNCHD_CFG_PATH="org.ocsng.agent.plist"
+SERVERDIR_CFG_PATH="serverdir"
+NOW_PATH="now"
+CACERT_PATH="cacert.pem"
+
+
+#Create temporary dir neeeded by postinstall script
+mkdir -p $TMP_DIR 
+
+if [ -f "$RESOURCES/$AGENT_CFG_PATH" ]
+then
+  cp $RESOURCES/$AGENT_CFG_PATH $TMP_DIR 
+fi
+
+if [ -f "$RESOURCES/$MODULES_CFG_PATH" ]
+then
+  cp $RESOURCES/$MODULES_CFG_PATH $TMP_DIR
+fi
+
+if [ -f "$RESOURCES/$LAUNCHD_CFG_PATH" ]
+then
+  cp $RESOURCES/$LAUNCHD_CFG_PATH $TMP_DIR
+fi
+
+if [ -f "$RESOURCES/$SERVERDIR_CFG_PATH" ]
+then
+  cp $RESOURCES/$SERVERDIR_CFG_PATH $TMP_DIR
+fi
+
+if [ -f "$RESOURCES/$NOW_PATH" ] 
+then
+  cp $RESOURCES/$NOW_PATH $TMP_DIR
+fi
+
+if [ -f "$RESOURCES/$CACERT_PATH" ]
+then
+  cp $RESOURCES/$CACERT_PATH $TMP_DIR 
+fi

--- a/macosx/ocsinventory_packages_setup/scripts/preinstall
+++ b/macosx/ocsinventory_packages_setup/scripts/preinstall
@@ -1,10 +1,6 @@
 #!/bin/sh
 
 #Setting path to package resources directory
-RESOURCES=$1/Contents/Resources
-# resources path if off
-
-#Setting path to package resources directory
 BASERESOURCES=$(dirname "$1")
 RESOURCES="$BASERESOURCES/../Resources"
 
@@ -18,9 +14,6 @@ else
   TMP_DIR=/tmp/ocs_installer
 fi
 
-echo "preinstall from agent"
-echo $RESOURCES
-echo $TMP_DIR
 #Files we want to copy
 AGENT_CFG_PATH="ocsinventory-agent.cfg"
 MODULES_CFG_PATH="modules.conf"


### PR DESCRIPTION
## Status
**READY**

## Description
agent's configuration files were not created when installing the Mac agent using the packager, pr adds the preinstall script