### PR TITLE
Fix tag encoding

### DIFF
--- a/lib/Ocsinventory/Agent/AccountInfo.pm
+++ b/lib/Ocsinventory/Agent/AccountInfo.pm
@@ -3,6 +3,8 @@ package Ocsinventory::Agent::AccountInfo;
 use strict;
 use warnings;
 
+use Encode qw(decode);
+
 sub new {
     my (undef,$params) = @_;
 
@@ -51,7 +53,7 @@ sub new {
                 "The -t parameter will be ignored. Don't forget that the TAG value ".
                 "will be ignored by the server unless it has OCS_OPT_ACCEPT_TAG_UPDATE_FROM_CLIENT=1.");
         } else {
-          $self->{accountinfo}->{TAG} = $self->{config}->{tag};
+          $self->{accountinfo}->{TAG} = decode('UTF-8', $self->{config}->{tag});
         }
     }
     $self; #Because we have already blessed the object 

--- a/lib/Ocsinventory/Agent/Config.pm
+++ b/lib/Ocsinventory/Agent/Config.pm
@@ -89,7 +89,7 @@ sub loadFromCfgFile {
 
     $self->{configfile} = $file;
 
-    if (!open (CONFIG, '<:encoding(UTF-8)', $file)) {
+    if (!open (CONFIG, '<'.$file)) {
         print(STDERR "Config: Failed to open $file\n");
 	    return $config;
     }

--- a/lib/Ocsinventory/Agent/Config.pm
+++ b/lib/Ocsinventory/Agent/Config.pm
@@ -89,7 +89,7 @@ sub loadFromCfgFile {
 
     $self->{configfile} = $file;
 
-    if (!open (CONFIG, "<".$file)) {
+    if (!open (CONFIG, '<:encoding(UTF-8)', $file)) {
         print(STDERR "Config: Failed to open $file\n");
 	    return $config;
     }


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes TAG value containing accented characters (é) being wrongly encoded and displayed in OCS GUI if TAG was sent from the agent.
