### PR TITLE
Fix Mem Module

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Solaris/Mem.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Solaris/Mem.pm
@@ -14,7 +14,7 @@ sub run {
     #my $unit = 1024;
 
     my $PhysicalMemory;
-    my $SwapFileSize;
+    my $SwapFileSize=0;
 
     # Memory informations
     foreach(`prtconf`){
@@ -25,7 +25,7 @@ sub run {
 
     #Swap Informations 
     foreach(`swap -l`){
-      if(/\s+(\S+)$/){$SwapFileSize = $1}; 
+      if(/(\d+)(?!.*\d)/g){$SwapFileSize = $SwapFileSize + $1};
     }
 
     $common->setHardware({


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Fix the mem.pm module on OS Solaris.

## Related Issues
https://github.com/OCSInventory-NG/UnixAgent/issues/423

## Todos
- [X] Tests
- [X] Documentation

## Test environment
root@sol11lab2:/usr/perl5# swap -l
swapfile      dev      swaplo      blocks      free      encrypted
/dev/zvol/dsk/rpool/swap      251,5      0      16777216      16777216      yes
/dev/zvol/dsk/rpool/swap1      251,6      0      4194304      4194304      yes

![Captura de tela de 2022-11-04 11-04-45](https://user-images.githubusercontent.com/54941941/199993486-e31352a0-0a82-4f35-a68b-af3e2554214c.png)

#### General informations
Operating system :  Solaris
Perl version : 5.32.0

#### OCS Inventory informations
Unix agent version : v2.10.0


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1. Change line 17(Initialize variable to 0 so it can sum on line 28)
2. Change line 28(Fix the regex and sum when the host have more than 1 swap)

## Impacted Areas in Application
List general components of the application that this PR will affect:

*Will fix the module UnixAgent/tree/master/lib/Ocsinventory/Agent/Backend/OS/Solaris/Mem.pm
