### PR TITLE
fix(software): fix wrong month in softwares installation date

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
@@ -27,7 +27,7 @@ sub run {
     foreach my $file_list (@listfile){
         my $stat=stat($file_list);
         my ($year,$month,$day,$hour,$min,$sec)=(localtime($stat->mtime))[5,4,3,2,1,0];
-        $value=sprintf "%02d/%02d/%02d %02d:%02d:%02d",($year+1900),$month,$day,$hour,$min,$sec;
+        $value=sprintf "%02d/%02d/%02d %02d:%02d:%02d",($year+1900),($month+1),$day,$hour,$min,$sec;
         $key=fileparse($file_list, ".list");
         $key =~ s/(\s+):.+/$1/;
         $statinfo{$key}=$value;


### PR DESCRIPTION
## Status
**READY**

## Description
The localtime() function returns months indexed from 0 to 11, but the installation month returned by the agent was always off by one month.

Add +1 to the month to get the correct value