### PR TITLE
Add OCSSSL which can be used to disable HTTPS cert check

### DIFF
--- a/contrib/cron/ocsinventory-agent.cron
+++ b/contrib/cron/ocsinventory-agent.cron
@@ -1,7 +1,7 @@
 #!/bin/bash
 NAME=ocsinventory-agent
 
-exec >>/var/log/$NAME/$NAME.log 2>&1 
+exec >>/var/log/$NAME/$NAME.log 2>&1
 
 [ -f   /etc/sysconfig/$NAME ] || exit 0
 source /etc/sysconfig/$NAME
@@ -17,19 +17,19 @@ do
 		fi
 
 		if [ ! -z "${OCSTAG[$i]}" ]; then
-		        OPTS="$OPTS --tag=${OCSTAG[$i]}"
+			OPTS="$OPTS --tag=${OCSTAG[$i]}"
 		fi
 
 		if [ "z${OCSSERVER[$i]}" = 'zlocal' ]; then
-	        	# Local inventory
-	        	OPTS="$OPTS --local=/var/lib/$NAME"
+			# Local inventory
+			OPTS="$OPTS --local=/var/lib/$NAME"
 
 		elif [ ! -z "${OCSSERVER[$i]}" ]; then
-	        	# Remote inventory
-		        OPTS="$OPTS --lazy --nolocal --server=${OCSSERVER[$i]}"
-		        if [ ! -z "${OCSPROXYSERVER[$i]}" ]; then
-		        	OPTS="$OPTS --proxy=${OCSPROXYSERVER[$i]}"
-		        fi
+			# Remote inventory
+			OPTS="$OPTS --lazy --nolocal --server=${OCSSERVER[$i]}"
+			if [ ! -z "${OCSPROXYSERVER[$i]}" ]; then
+				OPTS="$OPTS --proxy=${OCSPROXYSERVER[$i]}"
+			fi
 		fi
 
 		echo "[$(date '+%c')] Running $NAME $OPTS"
@@ -38,4 +38,3 @@ do
 	((i++))
 done
 echo "[$(date '+%c')] End of cron job ($PATH)"
-

--- a/contrib/cron/ocsinventory-agent.cron
+++ b/contrib/cron/ocsinventory-agent.cron
@@ -32,6 +32,10 @@ do
 			fi
 		fi
 
+		if [ ! -z "${OCSSSL[$i]}" ]; then
+			OPTS="$OPTS --ssl=${OCSSSL[$i]}"
+		fi
+
 		echo "[$(date '+%c')] Running $NAME $OPTS"
 		/usr/sbin/$NAME  $OPTS
 	fi

--- a/contrib/cron/ocsinventory-agent.sysconf
+++ b/contrib/cron/ocsinventory-agent.sysconf
@@ -12,9 +12,12 @@ OCSMODE[0]=none
 ## can be used to override the ocsinventory-agent.cfg setup.
 # OCSSERVER[0]=your.ocsserver.name
 #
+## can be used to disable HTTPS cert check.
+# OCSSSL[0]=0
+#
 ## If you need an HTTP/HTTPS proxy, fill this out
 # OCSPROXYSERVER[0]='http://user:pass@proxy:port'
-## 
+#
 ## corresponds with --local=/var/lib/ocsinventory-agent
 OCSSERVER[0]=local
 


### PR DESCRIPTION
## Status
**READY**

## Description
It adds a variable which can be set in order to disable HTTPS cert check. Currently I need to manually modify `/usr/libexec/ocsinventory-agent/ocsinventory-agent.cron` which is incovenient, because this file is overwritten on package upgrade on CentOS/Fedora.

The following patch for the rpm spec file is also needed:
```
--- ocsinventory-agent.spec.orig	2022-10-17 16:56:26.000000000 +0300
+++ ocsinventory-agent.spec	2023-03-28 17:55:25.535739778 +0300
@@ -180,7 +180,10 @@
 
 # can be used to override the %{name}.cfg setup.
 # OCSSERVER[0]=your.ocsserver.name
-# 
+#
+# can be used to disable HTTPS cert check.
+# OCSSSL[0]=0
+#
 # corresponds with --local=%{_localstatedir}/lib/%{name}
 # OCSSERVER[0]=local
 %endif
```
