### PR TITLE
Feat add software last update, update type and installation method

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Generic/Packaging/Deb.pm
@@ -48,6 +48,12 @@ sub run {
     my @auto_IM = `apt-mark showauto`;
     my $installationMethod;
 
+    my @updates = `apt list --upgradable 2>/dev/null`;
+    my $name;
+    my $type;
+    my $lastUpdate;
+    my $updateType;
+
     foreach my $line (@infos) {
         next if $line =~ /^ /;
         chomp $line;
@@ -62,6 +68,7 @@ sub run {
             if ($package eq $deb[0])
             {
                 $installationMethod = "Manual";
+                last;
             }
         }
         foreach my $package (@auto_IM)
@@ -70,6 +77,38 @@ sub run {
             if ($package eq $deb[0])
             {
                 $installationMethod = "Automatic";
+                last;
+            }
+        }
+        foreach my $package (@updates)
+        {
+            $lastUpdate = "";
+            $updateType = "";
+            if ($package =~ /(?<package>\S+)?\/(?<type>\S+) (?<update_version>\S+) (?<architecture>\S+) \[.+?: (?<current_version>\S+)?\]/)
+            {
+                $name = $1;
+                if ($name eq $deb[0])
+                {
+                    $lastUpdate = $3;
+                    $type = $2;
+
+                    if ($type =~ /security/)
+                    {
+                        $updateType = "Security";
+                    }
+                    if ($type =~ /updates/)
+                    {
+                        $updateType = "Updates";
+                    }
+                    if ($type =~ /security/)
+                    {
+                        if ($type =~ /updates/)
+                        {
+                            $updateType = "Security and updates";
+                        }
+                    }
+                    last;
+                }
             }
         }
         $key=$deb[0];
@@ -78,10 +117,12 @@ sub run {
                 'NAME'          => $deb[0],
                 'ARCHITECTURE'  => $deb[1],
                 'VERSION'       => $deb[2],
+                'LASTUPDATE'    => $lastUpdate,
+                'UPDATETYPE'    => $updateType,
                 'FILESIZE'      => ( $deb[3] || 0 ) * 1024,
                 'PUBLISHER'     => $deb[5],
                 'INSTALLDATE'   => $statinfo{$key},
-                'INSTALLMETHOD'  => $installationMethod,
+                'INSTALLMETHOD' => $installationMethod,
                 'COMMENTS'      => $deb[6],
                 'FROM'          => 'deb'
             });

--- a/lib/Ocsinventory/Agent/Common.pm
+++ b/lib/Ocsinventory/Agent/Common.pm
@@ -362,7 +362,7 @@ sub addSoftware {
 
     my $content = {};
 
-    foreach my $key (qw/STATUS ARCHITECTURE COMMENTS FILESIZE FOLDER FROM INSTALLDATE INSTALLMETHOD NAME PUBLISHER VERSION/) {
+    foreach my $key (qw/STATUS ARCHITECTURE COMMENTS FILESIZE FOLDER FROM INSTALLDATE INSTALLMETHOD NAME PUBLISHER VERSION LASTUPDATE UPDATETYPE/) {
         if (exists $args->{$key}) {
             $content->{$key}[0] = $args->{$key} if $args->{$key};
         }

--- a/lib/Ocsinventory/Agent/Common.pm
+++ b/lib/Ocsinventory/Agent/Common.pm
@@ -362,7 +362,7 @@ sub addSoftware {
 
     my $content = {};
 
-    foreach my $key (qw/STATUS ARCHITECTURE COMMENTS FILESIZE FOLDER FROM INSTALLDATE NAME PUBLISHER VERSION/) {
+    foreach my $key (qw/STATUS ARCHITECTURE COMMENTS FILESIZE FOLDER FROM INSTALLDATE INSTALLMETHOD NAME PUBLISHER VERSION/) {
         if (exists $args->{$key}) {
             $content->{$key}[0] = $args->{$key} if $args->{$key};
         }


### PR DESCRIPTION
## Status
**READY**

## Description
Linux Agent are now able to gather software installation method, last update and update type for apt packages.

## Related Issues
Support Ticket

#### General informations
Operating system :  Linux
Perl version : 5.34.0

#### OCS Inventory informations
Unix agent version : 2.8.0