### PR TITLE
Mac fixes

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/CPU.pm
@@ -27,6 +27,13 @@ sub run {
        $datawidth = 32;
     }
 
+    my $arm64 = `sysctl -n hw.optional.arm64`;
+    if ($arm64 == 1){
+       $arch = "arm64";
+       $datawidth = 64;
+    }
+
+
     # How much processor socket ?
     my $ncpu=`sysctl -n hw.packages`;
 

--- a/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/MacOS/Mem.pm
@@ -26,57 +26,92 @@ sub run {
     #  $h = $h->{'Memory Slots'};
     #}
 
+    my $size;
+    my $speed;
+    my $type;
+    my $description;
+    my $serialnumber;
+    my $status;
+    my $numslots;
+
 
     foreach my $memory (@$data){
-        next unless $memory->{'_name'} =~ /^BANK|SODIMM|DIMM/;
-        # tare out the slot number
-        my $slot = $memory->{'_name'};
-	# memory in 10.5
-        if($slot =~ /^BANK (\d)\/DIMM\d/){
-            $slot = $1;
-        }
-	# 10.4
-	if($slot =~ /^SODIMM(\d)\/.*$/){
-		$slot = $1;
-	}
-	# 10.4 PPC
-	if($slot =~ /^DIMM(\d)\/.*$/){
-		$slot = $1;
-	}
-
-	# 10.7
-	if ($slot =~ /^DIMM (\d)/) {
-		$slot = $1;
-	}
-
-        my $size = $memory->{'dimm_size'};
-
-        my $desc = $memory->{'dimm_part_number'};
-
-        if ($desc !~ /empty/ && $desc =~ s/^0x//) {
-            # dimm_part_number is an hex string, convert it to ascii
-            $desc =~ s/^0x//;
-	    # Trim filling "00" from part number, which causes invalid XML down the line.
-	    $desc =~ s/00//g;
-            $desc = pack "H*", $desc;
-            $desc =~ s/\s+$//;
-            # New macs might have some specific characters, perform a regex to fix it
-            $desc =~ s/(?!-)[[:punct:]]//g;
-        }
-
-        # if system_profiler lables the size in gigs, we need to trim it down to megs so it's displayed properly
-        if($size =~ /GB$/){
+        # macos 14
+        if ($memory->{'SPMemoryDataType'}) {
+            $size = $memory->{'SPMemoryDataType'};
+            if ($size =~ /GB$/) {
                 $size =~ s/GB$//;
                 $size *= 1024;
+            } elsif ($size =~ /MB$/) {
+                $size =~ s/MB$//;
+            }
+
+            $speed = $memory->{'dimm_speed'};
+            $type = $memory->{'dimm_type'};
+            $description = $memory->{'dimm_manufacturer'};
+            $serialnumber = $memory->{'dimm_serial_number'};
+            $status = $memory->{'dimm_status'};
+        } else {
+            next unless $memory->{'_name'} =~ /^BANK|SODIMM|DIMM/;
         }
+
+        # if special handling did not work, we try the old way
+        if (!defined($size)) {
+            # tare out the slot number
+            $numslots = $memory->{'_name'};
+            # memory in 10.5
+            if($numslots =~ /^BANK (\d)\/DIMM\d/){
+                $numslots = $1;
+            }
+            # 10.4
+            if($numslots =~ /^SODIMM(\d)\/.*$/){
+                $numslots = $1;
+            }
+            # 10.4 PPC
+            if($numslots =~ /^DIMM(\d)\/.*$/){
+                $numslots = $1;
+            }
+
+            # 10.7
+            if ($numslots =~ /^DIMM (\d)/) {
+                $numslots = $1;
+            }
+
+            $size = $memory->{'dimm_size'};
+
+            $description = $memory->{'dimm_part_number'};
+
+            if ($description !~ /empty/ && $description =~ s/^0x//) {
+                # dimm_part_number is an hex string, convert it to ascii
+                $description =~ s/^0x//;
+            # Trim filling "00" from part number, which causes invalid XML down the line.
+            $description =~ s/00//g;
+                $description = pack "H*", $description;
+                $description =~ s/\s+$//;
+                # New macs might have some specific characters, perform a regex to fix it
+                $description =~ s/(?!-)[[:punct:]]//g;
+            }
+
+            # if system_profiler lables the size in gigs, we need to trim it down to megs so it's displayed properly
+            if($size =~ /GB$/){
+                    $size =~ s/GB$//;
+                    $size *= 1024;
+            }
+
+            $speed = $memory->{'dimm_speed'};
+            $type = $memory->{'dimm_type'};
+            $serialnumber = $memory->{'dimm_serial_number'};
+            $status = 'Status: '.$memory->{'dimm_status'};
+        }
+
         $common->addMemory({
             'CAPACITY'      => $size,
-            'SPEED'         => $memory->{'dimm_speed'},
-            'TYPE'          => $memory->{'dimm_type'},
-            'SERIALNUMBER'  => $memory->{'dimm_serial_number'},
-            'DESCRIPTION'   => $desc,
-            'NUMSLOTS'      => $slot,
-            'CAPTION'       => 'Status: '.$memory->{'dimm_status'},
+            'SPEED'         => $speed,
+            'TYPE'          => $type,
+            'SERIALNUMBER'  => $serialnumber,
+            'DESCRIPTION'   => $description,
+            'NUMSLOTS'      => $numslots,
+            'CAPTION'       => $status,
         });
     }
 
@@ -86,4 +121,5 @@ sub run {
         MEMORY =>  $sysctl_memsize / 1024 / 1024,
     });
 }
+
 1;


### PR DESCRIPTION
## Status
**HOLD**

## Description
- Fix memory not returning anything on some mac devices : output of system_profiler SPMemoryDataType may have a different format, check for new format first then fallback to former process
- Fix wrong arch being retrieved for apple M1/M2 : check optional.arm64 


