### PR TITLE
fix(macOS): update perl shebang to use 5.30 version

### DIFF
--- a/macosx/patches/perl_sonoma.patch
+++ b/macosx/patches/perl_sonoma.patch
@@ -1,0 +1,8 @@
+--- ocsinventory-agent.orig	2024-05-14 17:10:08
++++ ocsinventory-agent	2024-05-14 17:09:16
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/perl5.30
+ 
+ eval 'exec /usr/bin/perl  -S $0 ${1+"$@"}'
+     if 0; # not running under some shell


### PR DESCRIPTION
## Status
**READY**

macOS 14.4+ requires setting the shebang to perl5.30 for the agent to run successfully. 
Adds a patch file for this modification to macosx patches
fixes #461 