### PR TITLE
fix(OSRelease): add fallback when os-release file is not in key = value format

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Distro/OSRelease.pm
@@ -6,58 +6,80 @@ use strict;
 sub check {
     my $params = shift;
     my $common = $params->{common};
-    $common->can_read ("/etc/os-release") 
+    $common->can_read("/etc/os-release");
 }
 
 sub run {
 
     my $name;
-    my $version;
-    my $description;
+    my $version     = "";
+    my $description = "";
 
     my $params = shift;
     my $common = $params->{common};
+    my $first_non_commented_line;
 
-    open V, "/etc/os-release" or warn;
-    foreach (<V>) {
-       next if /^#/;
-       $name = $1 if (/^NAME="?([^"]+)"?/);
-       $version = $1 if (/^VERSION_ID="?([^"]+)"?/);
-       $description=$1 if (/^PRETTY_NAME="?([^"]+)"?/);
+    open my $v, '<', "/etc/os-release" or warn;
+    foreach (<$v>) {
+        next if /^#/;
+        $first_non_commented_line //= $_; # Capture the first non-commented line
+        $name        = $1 if (/^NAME="?([^"]+)"?/);
+        $version     = $1 if (/^VERSION_ID="?([^"]+)"?/);
+        $description = $1 if (/^PRETTY_NAME="?([^"]+)"?/);
     }
-    close V;
-    chomp($name);
-    chomp($version);
-    chomp($description);
+    close $v;
+
+    $name = $first_non_commented_line unless defined $name;
+
+    chomp($name)        if defined $name;
+    chomp($version)     if defined $version;
+    chomp($description) if defined $description;
 
     # Debian version number is set in/etc/debian_version file
-    if (-r "/etc/debian_version") {
-        if (`uname -v` =~ /debian/i) {
-            open V, "/etc/debian_version" or warn;
-            foreach (<V>) {
-                $version = $1 if ($_ =~ /^(\d+.*)/);
+    if ( -r "/etc/debian_version" ) {
+        if ( `uname -v` =~ /debian/i ) {
+            open my $v, '<', "/etc/debian_version" or warn;
+            foreach (<$v>) {
+                $version = $1 if ( $_ =~ /^(\d+.*)/ );
             }
-            close V;
-            chomp($version);
-	}
+            close $v;
+            chomp($version) if defined $version;
+        }
     }
 
     # CentOS exact version number is set in /etc/centos-release file
-    if (-r "/etc/centos-release") {
-        open V, "/etc/centos-release" or warn;
-        foreach ($description=<V>) {
-            $version = $1 if ($_ =~ /(\d+\.\d+)./g);
+    my @centOsRedHatfiles = ( "/etc/centos-release", "/etc/redhat-release" );
+    foreach my $file (@centOsRedHatfiles) {
+        if ( -r $file ) {
+            open my $v, '<', $file or warn;
+            foreach my $line (<$v>) {
+                $version     = $1 if ( $line =~ /(\d+\.\d+)./g );
+                $description = $line;
+            }
+            close $v;
+            chomp($version)     if defined $version;
+            chomp($description) if defined $description;
+            last;    # Exit the loop after finding the first matching file
         }
-        close V;
-        chomp($version);
-        chomp($description);
     }
 
-    $common->setHardware({
-        OSNAME => "$name $version",
-        OSVERSION => $version,
-        OSCOMMENTS => $description,
-    });
+    if ( !defined $version || $version eq "" ) {
+
+   # if no version found try to retrieve it on the name with format x.x or x.x.x
+        $version = $1 if ( $name =~ /^(\d+.*)/ );
+    }
+
+    my $fullosname = $name;
+    $fullosname .= " $version" if $version;
+    $fullosname =~ s/^\s+|\s+$//g;
+
+    $common->setHardware(
+        {
+            OSNAME     => $fullosname,
+            OSVERSION  => $version,
+            OSCOMMENTS => $description,
+        }
+    );
 
 }
 


### PR DESCRIPTION
## Status
**READY**

## Description
In the case the os-release file is not using the standard KEY=VALUE format, it trigger and error and no OS is retrived

## Test environment

- Ubuntu 20.04
- Ubuntu 22.04
- Rhel 9
- Rhel 7

#### OCS Inventory informations
Unix agent version : latest

## Impacted Areas in Application
List general components of the application that this PR will affect:

* OS Retrieval
