### PR TITLE
fix: disable case sensitivity for single-letter options in GetOpt-Long

### DIFF
--- a/lib/Ocsinventory/Agent/Config.pm
+++ b/lib/Ocsinventory/Agent/Config.pm
@@ -1,7 +1,7 @@
 package Ocsinventory::Agent::Config;
 
 use strict;
-use Getopt::Long;
+use Getopt::Long qw(:config no_ignore_case);
 
 our $VERSION = '2.10.4';
 


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
READY

## Description

This PR resolves warnings caused by a breaking change in the `Getopt-Long` package with version 2.55, see:

* https://github.com/sciurius/perl-Getopt-Long/releases/tag/R2.57
* https://github.com/sciurius/perl-Getopt-Long/commit/5b5647b709fec087d2b7a31f7a613441d989d480
    
As of this version, single-letter options in `Getopt-Long` are case-sensitive by default, leading to the following warnings when running `ocsinventory-agent`:

```
Duplicate specification "R|remotedir=s" for option "r"
Duplicate specification "p|password=s" for option "p"
```

These warnings are caused by a breaking change in Getopt-Long v2.55, which enforces case-sensitive handling for single-letter options—something OCS Inventory Agent wasn’t expecting with the -p/-P, -r/-R single-letter options. In future versions of Getopt-Long, this change will produce fatal errors.

A resolution is to disable case sensitivity by explicitly configuring Getopt-Long with the `no_ignore_case`.

## Related Issues

In the NixOS/nixpkgs repository: https://github.com/NixOS/nixpkgs/pull/351733#pullrequestreview-2401383409

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system : NixOS 24.05
Perl version : 5.40

#### OCS Inventory informations
Unix agent version : 2.10.3

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* CLI option parser
