### PR TITLE
Fix type, NBSOCKETS isn't defined

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
@@ -64,8 +64,8 @@ sub run {
     if ($cpu->{NBSOCKET} and $cpu->{CORES} and $cpu->{THREADS} ){
         if ($cpu->{THREADS} >= $cpu->{CORES}) {
             $cpu->{THREADS}=$cpu->{THREADS}/$cpu->{CORES};
-        } elsif ($cpu->{THREADS} >= $cpu->{NBSOCKETS}) {
-            $cpu->{THREADS}=$cpu->{THREADS}/$cpu->{NBSOCKETS};
+        } elsif ($cpu->{THREADS} >= $cpu->{NBSOCKET}) {
+            $cpu->{THREADS}=$cpu->{THREADS}/$cpu->{NBSOCKET};
         }
     }
 


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
NBSOCKETS isn't defined and the following warning is emitted:
```
Use of uninitialized value in numeric ge (>=) at
/usr/local/lib/perl5/site_perl/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
line 67.
Use of uninitialized value in division (/) at
/usr/local/lib/perl5/site_perl/Ocsinventory/Agent/Backend/OS/BSD/CPU.pm
line 68.
```

## Test environment
tested on FreeBSD, unix agent v2.10.4

#### General informations
Operating system :  FreeBSD 15.0-CURRENT
Perl version : his is perl 5, version 36, subversion 3 (v5.36.3) built for amd64-freebsd-thread-multi

#### OCS Inventory informations
Unix agent version : ocsinventory-agent-2.10.4,1