### PR TITLE
Ignore overlay filesystems in drive detection

### DIFF
--- a/lib/Ocsinventory/Agent/Backend/OS/Linux/Drives.pm
+++ b/lib/Ocsinventory/Agent/Backend/OS/Linux/Drives.pm
@@ -79,7 +79,7 @@ sub run {
             $volumn = $1;
 
             # no virtual FS
-            next if ($filesystem =~ /^(tmpfs|devtmpfs|usbfs|proc|devpts|devshm|udev)$/);
+            next if ($filesystem =~ /^(tmpfs|devtmpfs|usbfs|proc|devpts|devshm|udev|overlay)$/);
             next if ($type =~ /^(tmpfs|devtmpfs)$/);
 
             if ($filesystem =~ /^ext(2|3|4|4dev)/ && $common->can_run('dumpe2fs')) {


### PR DESCRIPTION
## Status
**READY**

## Description
Overlays are used by Docker to run container and replicate storage used by the original mount point. When the agent is ran on the machine, theses mounts are sent to the OCS Server.

Here an example of the `df -TP` (the command use in OCS Agent)
```
Filesystem                    Type     1024-blocks    Used Available Capacity Mounted on
udev                          devtmpfs     4037924       0   4037924       0% /dev
tmpfs                         tmpfs         813132     808    812324       1% /run
/dev/mapper/debian_vg-root_lv ext4        91237332 7091856  80098528       9% /
tmpfs                         tmpfs        4065644       0   4065644       0% /dev/shm
tmpfs                         tmpfs           5120       0      5120       0% /run/lock
/dev/sda1                     ext2          454492  122984    307137      29% /boot
overlay                       overlay     91237332 7091856  80098528       9% /var/lib/docker/overlay2/1dcbb04a78f2b29e7657033f4d8fe4f273fa4accd50436234e8841479abe5715/merged
tmpfs                         tmpfs         813128       0    813128       0% /run/user/0
```

You can see that `/var/lib/docker/overlay2/1dcbb04a78f2b29e7657033f4d8fe4f273fa4accd50436234e8841479abe5715/merged` mimic the information of `/` where the files are originally saved.

## Related Issues
_No related issues found_

## Todos
- [x] Tests
- [ ] Documentation

## Test environment
Patch tested on a machine with Docker CE 29.2.0 installed and a container running.

#### General informations
Operating system :  Debian 12.13
Perl version : v5.36.0

#### OCS Inventory informations
Unix agent version : 2.10.0


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any dependencies changes,
logical changes, etc.

_None_ 

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Drives on Linux machines
